### PR TITLE
Use a workaround to consistently get workflow run conclusion

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,6 +14,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch || 'main' }}
+  cancel-in-progress: true
+
 jobs:
   # Deploy to Cloudflare Pages main site on push to main or workflow_dispatch
   test-and-build-prod:
@@ -45,8 +49,30 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
   # Deploy to Cloudflare Pages preview site on PR
+  get_workflow_conclusion:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
+    name: Lookup Conclusion of Workflow_Run Event
+    runs-on: ubuntu-latest
+    outputs:
+      conclusion: ${{ steps.get_conclusion.outputs.conclusion }}
+    steps:
+      - name: Get Workflow Run
+        uses: actions/github-script@v7
+        id: get_conclusion
+        with:
+          script: |
+            const response = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            });
+            
+            return response.data.conclusion;
+          result-encoding: string
+
   deploy-pr:
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && needs.get_workflow_conclusion.outputs.conclusion == 'success'
+    needs: get_workflow_conclusion
     runs-on: ubuntu-latest
     name: Deploy
     permissions:

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -3,28 +3,9 @@ name: Maintenance checks & jobs on PRs
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  # This is used to upload the PR number to be used in dependent workflows
-  upload-pr:
-    name: Upload PR
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Save PR number to file
-        run: echo ${{ github.event.number }} > pr-number
-
-      - name: Upload pr-number
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-number
-          path: pr-number
-
   # Check that PR has a minimum set of labels as required by our release drafter
   check-pr-labels:
     name: Check PR Labels

--- a/.github/workflows/pr-post-test.yml
+++ b/.github/workflows/pr-post-test.yml
@@ -11,12 +11,34 @@ permissions:
   checks: write
 
 jobs:
+  get_workflow_conclusion:
+    if: github.event.workflow_run.event == 'pull_request'
+    name: Lookup Conclusion of Workflow_Run Event
+    runs-on: ubuntu-latest
+    outputs:
+      conclusion: ${{ steps.get_conclusion.outputs.conclusion }}
+    steps:
+      - name: Get Workflow Run
+        uses: actions/github-script@v7
+        id: get_conclusion
+        with:
+          script: |
+            const response = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            });
+            
+            return response.data.conclusion;
+          result-encoding: string
+
   update-pr:
     name: Update PR with test results
     runs-on: ubuntu-latest
+    needs: get_workflow_conclusion
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.event == 'pull_request' 
+      && needs.get_workflow_conclusion.outputs.conclusion == 'success'
 
     steps:
       - name: Download Test Report


### PR DESCRIPTION
## Description

Attempt to workaround GitHub bug with workflow_run trigger

## Related Issues

Fixes #57

## How to Test

No code changes

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
