### PR TITLE
Cast decimal to double in query results

### DIFF
--- a/src/features/app-context/db-worker.ts
+++ b/src/features/app-context/db-worker.ts
@@ -24,6 +24,13 @@ async function initDB() {
     const worker = new Worker(worker_url);
     db = new duckdb.AsyncDuckDB(logger, worker);
     await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+    await db.open({
+      query: {
+        // Enable Apache Arrow type and value patching DECIMAL -> DOUBLE on query materialization
+        // https://github.com/apache/arrow/issues/37920
+        castDecimalToDouble: true,
+      },
+    });
 
     // Load parquet extension
     // await loadExtension(db, 'parquet');

--- a/src/features/data-viewer/hooks/useColumnSummary.tsx
+++ b/src/features/data-viewer/hooks/useColumnSummary.tsx
@@ -32,8 +32,8 @@ export const useColumnSummary = () => {
       }
 
       const summaryQuery = isNumeric
-        ? `SELECT CAST(sum("${columnName}") AS DOUBLE) as total FROM (${originalQuery});`
-        : `SELECT COUNT("${columnName}") as total FROM (${originalQuery});`;
+        ? `SELECT sum("${columnName}") AS total FROM (${originalQuery});`
+        : `SELECT count("${columnName}") AS total FROM (${originalQuery});`;
 
       setIsCalculating(true);
       const queryResult = await executeQuery(summaryQuery);

--- a/tests/integration/query/query.spec.ts
+++ b/tests/integration/query/query.spec.ts
@@ -28,6 +28,28 @@ test('Create and run simple query', async ({
   await assertDataTableMatches({ 1: [1] });
 });
 
+test('Create and run query with decimals', async ({
+  createQueryAndSwitchToItsTab,
+  fillQuery,
+  runQuery,
+  assertDataTableMatches,
+}) => {
+  await createQueryAndSwitchToItsTab();
+  await fillQuery(`
+    select
+      sum(col1) as col1,
+      0.5 as col2,
+      (-123.123)::DECIMAL(10,2) as col3,
+      1::INT128 as col4
+    from (
+      select 1 as col1
+      union select 2 as col1
+    )
+  `);
+  await runQuery();
+  await assertDataTableMatches({ col1: [3], col2: [0.5], col3: [-123.12], col4: [1] });
+});
+
 test('Close and reopen query', async ({
   createQueryAndSwitchToItsTab,
   fillQuery,


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes in this PR -->

Band aid for DECIMAL presentation problem

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" -->
Related to #43 

## How to Test

<!-- Provide step-by-step instructions on how to test this PR -->
Any expression that returns a decimal is now serialized as a double, eg:
select 1.1
select 1::DECIMAL


## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
