### PR TITLE
[Bug]: Re-register loaded files when their contents have changed

### DIFF
--- a/src/features/app-context/db-worker.ts
+++ b/src/features/app-context/db-worker.ts
@@ -107,11 +107,12 @@ async function getTablesAndColumns(database_name?: string, schema_name?: string)
  *
  * @param fileName - Name of the file
  * @param handle - File handle
+ * @returns Registered file content
  */
 async function registerFileHandleAndCreateDBInstance(
   fileName: string,
   handle: FileSystemFileHandle,
-) {
+): Promise<File> {
   const conn = await db?.connect();
   const formatSupported = ['.csv', '.parquet', '.duckdb', '.json', '.xlsx'].some((ext) =>
     fileName.endsWith(ext),
@@ -142,6 +143,8 @@ async function registerFileHandleAndCreateDBInstance(
   }
 
   await conn.close();
+
+  return file;
 }
 
 /**

--- a/src/features/app-context/models.ts
+++ b/src/features/app-context/models.ts
@@ -51,7 +51,7 @@ export interface DBWorkerAPIType {
   registerFileHandleAndCreateDBInstance: (
     fileName: string,
     handle: FileSystemFileHandle,
-  ) => Promise<void>;
+  ) => Promise<File>;
   dropFilesAndDBInstances: (paths: string[], type: 'database' | 'view') => Promise<void>;
   getDBUserInstances: (type: 'databases' | 'views') => Promise<Uint8Array>;
   getTablesAndColumns: (database?: string, schema?: string) => Promise<Uint8Array<ArrayBufferLike>>;

--- a/src/features/app-context/utils.ts
+++ b/src/features/app-context/utils.ts
@@ -267,3 +267,24 @@ export const buildColumnsQueryWithFilters = (
     ORDER BY database_name, schema_name, table_name, column_index;
   `;
 };
+
+export type FileReadabilityStatus = 'readable' | 'notFound' | 'notReadable';
+
+export const checkFileReadability = async (
+  file: File | FileSystemFileHandle,
+): Promise<FileReadabilityStatus> => {
+  try {
+    const f = file instanceof File ? file : await file.getFile();
+    // Cheapest and shortest way to check if the file is readable is to slice the first byte
+    await f.slice(0, 1).arrayBuffer();
+    return 'readable';
+  } catch (error: any) {
+    if (error.name === 'NotFoundError') {
+      return 'notFound';
+    }
+    if (error.name === 'NotReadableError') {
+      return 'notReadable';
+    }
+  }
+  return 'notReadable';
+};

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -23,6 +23,7 @@ interface AppStateModel {
 
   views: string[];
   sessionFiles: SessionFiles | null;
+  registeredFileHandleContent: Record<string, File>;
 
   queries: CodeEditor[];
   tabs: TabModel[];
@@ -47,6 +48,8 @@ interface AppStateModel {
   setCachedResults: (key: string, value: Table | null) => void;
   setCachedPagination: (key: string, value: CachedPaginationValue | null) => void;
   setSessionFiles: (v: SessionFiles | null) => void;
+  setBatchRegisteredFileHandleContent: (updates: Record<string, File>) => void;
+  removeBatchRegisteredFileHandleContent: (keys: string[]) => void;
 }
 
 export const useAppStore = create<AppStateModel>()((set) => ({
@@ -54,6 +57,7 @@ export const useAppStore = create<AppStateModel>()((set) => ({
   databases: [],
   queries: [],
   sessionFiles: null,
+  registeredFileHandleContent: {},
 
   tabs: [],
   cachedResults: {},
@@ -93,4 +97,27 @@ export const useAppStore = create<AppStateModel>()((set) => ({
         [key]: value,
       },
     })),
+  setBatchRegisteredFileHandleContent: (updates) =>
+    set((state) => {
+      if (Object.keys(updates).length === 0) {
+        return { registeredFileHandleContent: state.registeredFileHandleContent };
+      }
+      return {
+        registeredFileHandleContent: {
+          ...state.registeredFileHandleContent,
+          ...updates,
+        },
+      };
+    }),
+  removeBatchRegisteredFileHandleContent: (keys) =>
+    set((state) => {
+      if (keys.length === 0) {
+        return { registeredFileHandleContent: state.registeredFileHandleContent };
+      }
+      const newContent = { ...state.registeredFileHandleContent };
+      keys.forEach((key) => {
+        delete newContent[key];
+      });
+      return { registeredFileHandleContent: newContent };
+    }),
 }));


### PR DESCRIPTION
## Description

✨ checkFileReadability helper
✨ syncFiles function that called when running query fails due to NotReadableError

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" -->
Fixes #58

## How to Test

See how to reproduce in #58

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
