### PR TITLE
[Feature]: Add automatic retry when file source was moved or changed

### DIFF
--- a/src/controllers/data-source/data-view-source.ts
+++ b/src/controllers/data-source/data-view-source.ts
@@ -56,6 +56,7 @@ export const deleteDataSources = async (
     activeTabId,
     previewTabId,
     localEntries,
+    registeredFiles,
     _iDbConn: iDbConn,
   } = useAppStore.getState();
 
@@ -116,12 +117,16 @@ export const deleteDataSources = async (
   const newLocalEntires = new Map(
     Array.from(localEntries).filter(([id, _]) => !entryIdsToDelete.has(id)),
   );
+  const newRegisteredFiles = new Map(
+    Array.from(registeredFiles).filter(([id, _]) => !entryIdsToDelete.has(id)),
+  );
 
   // Update the store with the new state
   useAppStore.setState(
     {
       dataSources: newDataSources,
       localEntries: newLocalEntires,
+      registeredFiles: newRegisteredFiles,
       tabs: newTabs,
       tabOrder: newTabOrder,
       activeTabId: newActiveTabId,

--- a/src/controllers/db/data-source.ts
+++ b/src/controllers/db/data-source.ts
@@ -25,7 +25,7 @@ export async function registerFileSourceAndCreateView(
   fileExt: supportedFlatFileDataSourceFileExt,
   fileName: string,
   viewName: string,
-) {
+): Promise<File> {
   const file = await handle.getFile();
   const db = conn.bindings;
 
@@ -47,12 +47,13 @@ export async function registerFileSourceAndCreateView(
     await conn.query(
       `CREATE OR REPLACE VIEW ${toDuckDBIdentifier(viewName)} AS SELECT * FROM read_csv(${quote(fileName, { single: true })}, strict_mode=false);`,
     );
-    return;
+    return file;
   }
 
   await conn.query(
     `CREATE OR REPLACE VIEW ${toDuckDBIdentifier(viewName)} AS SELECT * FROM ${quote(fileName, { single: true })};`,
   );
+  return file;
 }
 
 /**
@@ -106,7 +107,7 @@ export async function registerAndAttachDatabase(
   handle: FileSystemFileHandle,
   fileName: string,
   dbName: string,
-) {
+): Promise<File> {
   const file = await handle.getFile();
   const db = conn.bindings;
 
@@ -131,6 +132,8 @@ export async function registerAndAttachDatabase(
   await conn.query(
     `ATTACH ${quote(fileName, { single: true })} as ${toDuckDBIdentifier(dbName)} (READ_ONLY);`,
   );
+
+  return file;
 }
 
 /**

--- a/src/features/tab-view/hooks/use-data-adapter.ts
+++ b/src/features/tab-view/hooks/use-data-adapter.ts
@@ -16,6 +16,8 @@ import { convertArrowTable, getArrowTableSchema } from '@utils/arrow';
 import { isTheSameSortSpec, toggleMultiColumnSort } from '@utils/db';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PoolTimeoutError } from '@features/duckdb-context/timeout-error';
+import { syncFiles } from '@controllers/file-system';
+import { useInitializedDuckDBConnectionPool } from '@features/duckdb-context/duckdb-context';
 import { useDataAdapterQueries } from './use-data-adapter-queries';
 
 // Data adapter is a logic layer between abstract batch streaming data source
@@ -34,6 +36,8 @@ type UseDataAdapterProps = {
 };
 
 export const useDataAdapter = ({ tab, sourceVersion }: UseDataAdapterProps): DataAdapterApi => {
+  const pool = useInitializedDuckDBConnectionPool();
+
   /**
    * Hooks
    */
@@ -329,119 +333,126 @@ export const useDataAdapter = ({ tab, sourceVersion }: UseDataAdapterProps): Dat
    * Only one of this can be running at a time (or othersise we have a bug).
    * See `fetchData` for the multi-call compatibile interface.
    */
-  const fetchDataSingleEntry = useCallback(async () => {
-    if (mainDataReaderRef.current === null) {
-      throw new Error('Main data reader is null while fetching data');
-    }
-
-    if (mainDataReaderRef.current.closed) {
-      throw new Error('Main data reader is closed while fetching data');
-    }
-
-    // Get the abort signal so all of this can be cancelled
-    const abortSignal = getDataFetchAbortSignal();
-
-    let readAll = false;
-    let inferredSchema: DBTableOrViewSchema | null = null;
-
-    // Set actual data schema on first read
-    let updateSchemaFromInferred = actualData.current.length === 0;
-
-    try {
-      // Stop fetching when the reader is done or fetch is cancelled
-      while (
-        !readAll &&
-        !mainDataReaderRef.current.closed &&
-        !abortSignal.aborted &&
-        // If we read enough data, we can stop
-        (fetchTo.current === null || actualData.current.length < fetchTo.current)
-      ) {
-        // Run an abortable read
-        const { done, value } = await Promise.race([
-          mainDataReaderRef.current.next(),
-          new Promise<never>((_, reject) => {
-            abortSignal.addEventListener('abort', () => {
-              reject(
-                new DOMException(
-                  'Operation cancelled as it was replaced by a newer copy/export request',
-                  'Cancelled',
-                ),
-              );
-            });
-          }),
-        ]);
-
-        if (done) {
-          readAll = true;
-          break;
-        }
-
-        const newTableData = convertArrowTable(value);
-
-        actualData.current.push(...newTableData);
-
-        // Infer schema once on first non empty batch
-        if (!inferredSchema) {
-          inferredSchema = getArrowTableSchema(value);
-        }
-
-        // Seet schema it this is the first read
-        // We do it here in the loop together with moving the data version
-        // and unsetting stale data instead of outside, to allow
-        // immediately showing the data to the user, even if we need
-        // to continue reading more data.
-        if (updateSchemaFromInferred) {
-          setActualDataSchema(inferredSchema);
-
-          updateSchemaFromInferred = false;
-        }
-
-        // We have read at least something, reset the stale data
-        setStaleData(null);
-        // Update loaded row count
-        setAvailableRowCount(actualData.current.length);
-        // And ping downstream components that data has changed
-        setDataVersion((prev) => prev + 1);
+  const fetchDataSingleEntry = useCallback(
+    async (options = { retry_with_file_sync: true }) => {
+      if (mainDataReaderRef.current === null) {
+        throw new Error('Main data reader is null while fetching data');
       }
-    } catch (error) {
-      if (!abortSignal.aborted) {
-        // Fetch was not cancelled we got an actual error
-        console.error('Failed to read data from the data source:', error);
-        setAppendDataSourceReadError(
-          'Failed to read data from the data source. See console for technical details.',
-        );
+
+      if (mainDataReaderRef.current.closed) {
+        throw new Error('Main data reader is closed while fetching data');
       }
-    }
 
-    // And do final updates after the end of the fetch loop or abort
-    const availableRowCount = actualData.current.length;
+      // Get the abort signal so all of this can be cancelled
+      const abortSignal = getDataFetchAbortSignal();
 
-    const newCachedStaleDataUpdate: Partial<StaleData> = {
-      data: actualData.current.slice(-MAX_PERSISTED_STALE_DATA_ROWS),
-      rowOffset: Math.max(0, actualData.current.length - MAX_PERSISTED_STALE_DATA_ROWS),
-    };
+      let readAll = false;
+      let inferredSchema: DBTableOrViewSchema | null = null;
 
-    if (inferredSchema) {
-      // We have a schema, so we can set it in the cache
-      newCachedStaleDataUpdate.schema = inferredSchema;
-    }
+      // Set actual data schema on first read
+      let updateSchemaFromInferred = actualData.current.length === 0;
 
-    if (readAll) {
-      // Now we know that we have read all the data
-      setDataSourceExhausted(true);
-      // Set the real row count
-      setRealRowCount(availableRowCount);
+      try {
+        // Stop fetching when the reader is done or fetch is cancelled
+        while (
+          !readAll &&
+          !mainDataReaderRef.current.closed &&
+          !abortSignal.aborted &&
+          // If we read enough data, we can stop
+          (fetchTo.current === null || actualData.current.length < fetchTo.current)
+        ) {
+          // Run an abortable read
+          const { done, value } = await Promise.race([
+            mainDataReaderRef.current.next(),
+            new Promise<never>((_, reject) => {
+              abortSignal.addEventListener('abort', () => {
+                reject(
+                  new DOMException(
+                    'Operation cancelled as it was replaced by a newer copy/export request',
+                    'Cancelled',
+                  ),
+                );
+              });
+            }),
+          ]);
 
-      // Also add info to the cache update object
-      newCachedStaleDataUpdate.realRowCount = availableRowCount;
-      newCachedStaleDataUpdate.estimatedRowCount = null;
-    }
+          if (done) {
+            readAll = true;
+            break;
+          }
 
-    updateTabDataViewStaleDataCache(tab.id, {
-      staleData: newCachedStaleDataUpdate,
-      sort,
-    });
-  }, [sort, getDataFetchAbortSignal]);
+          const newTableData = convertArrowTable(value);
+
+          actualData.current.push(...newTableData);
+
+          // Infer schema once on first non empty batch
+          if (!inferredSchema) {
+            inferredSchema = getArrowTableSchema(value);
+          }
+
+          // Seet schema it this is the first read
+          // We do it here in the loop together with moving the data version
+          // and unsetting stale data instead of outside, to allow
+          // immediately showing the data to the user, even if we need
+          // to continue reading more data.
+          if (updateSchemaFromInferred) {
+            setActualDataSchema(inferredSchema);
+
+            updateSchemaFromInferred = false;
+          }
+
+          // We have read at least something, reset the stale data
+          setStaleData(null);
+          // Update loaded row count
+          setAvailableRowCount(actualData.current.length);
+          // And ping downstream components that data has changed
+          setDataVersion((prev) => prev + 1);
+        }
+      } catch (error: any) {
+        if (error.message?.includes('NotReadableError') && options.retry_with_file_sync) {
+          await syncFiles(pool);
+          await fetchDataSingleEntry({ retry_with_file_sync: false });
+        }
+        if (!abortSignal.aborted) {
+          // Fetch was not cancelled we got an actual error
+          console.error('Failed to read data from the data source:', error);
+          setAppendDataSourceReadError(
+            'Failed to read data from the data source. See console for technical details.',
+          );
+        }
+      }
+
+      // And do final updates after the end of the fetch loop or abort
+      const availableRowCount = actualData.current.length;
+
+      const newCachedStaleDataUpdate: Partial<StaleData> = {
+        data: actualData.current.slice(-MAX_PERSISTED_STALE_DATA_ROWS),
+        rowOffset: Math.max(0, actualData.current.length - MAX_PERSISTED_STALE_DATA_ROWS),
+      };
+
+      if (inferredSchema) {
+        // We have a schema, so we can set it in the cache
+        newCachedStaleDataUpdate.schema = inferredSchema;
+      }
+
+      if (readAll) {
+        // Now we know that we have read all the data
+        setDataSourceExhausted(true);
+        // Set the real row count
+        setRealRowCount(availableRowCount);
+
+        // Also add info to the cache update object
+        newCachedStaleDataUpdate.realRowCount = availableRowCount;
+        newCachedStaleDataUpdate.estimatedRowCount = null;
+      }
+
+      updateTabDataViewStaleDataCache(tab.id, {
+        staleData: newCachedStaleDataUpdate,
+        sort,
+      });
+    },
+    [sort, getDataFetchAbortSignal, pool],
+  );
 
   /**
    * Abortable multi-entry function that fetches the data until `rowTo` rows are read
@@ -549,7 +560,10 @@ export const useDataAdapter = ({ tab, sourceVersion }: UseDataAdapterProps): Dat
     abortBackgroundTasks();
   };
 
-  const getNewReader = async (newSortParams: ColumnSortSpecList) => {
+  const getNewReader = async (
+    newSortParams: ColumnSortSpecList,
+    options = { retry_with_file_sync: true },
+  ) => {
     try {
       // Cancel the main data reader before creating a new one
       if (mainDataReaderRef.current) {
@@ -569,11 +583,14 @@ export const useDataAdapter = ({ tab, sourceVersion }: UseDataAdapterProps): Dat
           fetchRowCount();
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       if (error instanceof PoolTimeoutError) {
         setAppendDataSourceReadError(
           'Too many tabs open or operations running. Please wait and re-open this tab.',
         );
+      } else if (error.message?.includes('NotReadableError') && options.retry_with_file_sync) {
+        await syncFiles(pool);
+        await getNewReader(newSortParams, { retry_with_file_sync: false });
       } else {
         // Fetch was not cancelled we got an actual error
         console.error('Failed to create a reader for the data source:', error);

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -50,6 +50,11 @@ type AppStore = {
   localEntries: Map<LocalEntryId, LocalEntry>;
 
   /**
+   * A mapping of data source local file identifiers to their registered File objects.
+   */
+  registeredFiles: Map<LocalEntryId, File>;
+
+  /**
    * A mapping of SQL script identifiers to their corresponding SQLScript objects.
    */
   sqlScripts: Map<SQLScriptId, SQLScript>;
@@ -74,6 +79,7 @@ const initialState: AppStore = {
   appLoadState: 'init',
   dataSources: new Map(),
   localEntries: new Map(),
+  registeredFiles: new Map(),
   sqlScripts: new Map(),
   tabs: new Map(),
   dataBaseMetadata: new Map(),


### PR DESCRIPTION
## Description

Partial re-implementation of #97 
- All files sync
- Retry when query fails with NotReadableError error
- Retry when query fails with NotFoundError error
- Show nicer user message when we fail to recover

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" -->

## How to Test

<!-- Provide step-by-step instructions on how to test this PR -->

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
