### PR TITLE
[UX]: Add a close button on the settings page, improve query editor focus and minor UI tweaks

### DIFF
--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -343,22 +343,28 @@ export const SpotlightMenu = () => {
     );
   };
   const renderDataSourcesView = () => {
-    const filteredActions = filterActions(
-      [...dataSourceGroupActions, ...dataSourceActions],
-      searchValue,
-    );
+    const filteredActions = filterActions(dataSourceGroupActions, searchValue);
+    const filteredDataSources = filterActions(dataSourceActions, searchValue);
     // Can't be empty but ok...
-    return <>{filteredActions.length > 0 && renderActionsGroup(filteredActions, 'Data Sources')}</>;
+    return (
+      <>
+        {filteredActions.length > 0 && renderActionsGroup(filteredActions, 'Data Sources')}
+        {filteredDataSources.length > 0 &&
+          renderActionsGroup(filteredDataSources, 'Recent Data Sources')}
+      </>
+    );
   };
 
   const renderScriptsView = () => {
-    const filteredActions = filterActions([...scriptGroupActions, ...scriptActions], searchValue);
+    const filteredActions = filterActions(scriptGroupActions, searchValue);
+    const filteredScripts = filterActions(scriptActions, searchValue);
 
     // Can't be empty but ok...
     return (
       <>
         {filteredActions.length > 0 &&
           renderActionsGroup(filteredActions, SCRIPT_GROUP_DISPLAY_NAME)}
+        {filteredScripts.length > 0 && renderActionsGroup(filteredScripts, 'Recent Queries')}
       </>
     );
   };

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -1,5 +1,5 @@
 import { Group, useMantineColorScheme } from '@mantine/core';
-import { useDebouncedCallback } from '@mantine/hooks';
+import { useDebouncedCallback, useDidUpdate } from '@mantine/hooks';
 import { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { SqlEditor } from '@features/editor';
@@ -115,6 +115,12 @@ export const ScriptEditor = ({ id, active, runScriptQuery, scriptState }: Script
       }
     };
   }, []);
+
+  useDidUpdate(() => {
+    if (active) {
+      editorRef.current?.view?.focus();
+    }
+  }, [active]);
 
   return (
     <div

--- a/src/pages/settings-page/settings-page.tsx
+++ b/src/pages/settings-page/settings-page.tsx
@@ -1,12 +1,15 @@
-import { Box, Button, Divider, Group, Modal, Stack, Text, Title } from '@mantine/core';
+import { ActionIcon, Box, Button, Divider, Group, Modal, Stack, Text, Title } from '@mantine/core';
 import { setDataTestId } from '@utils/test-id';
 
 import { exportSQLScripts } from '@controllers/export-data';
 import { resetAppState } from '@store/app-store';
 import { useDisclosure } from '@mantine/hooks';
+import { IconX } from '@tabler/icons-react';
+import { useNavigate } from 'react-router-dom';
 import { ThemeSwitcher } from './components/theme-switcher';
 
 export const SettingsPage = () => {
+  const navigate = useNavigate();
   const [confirmOpened, { open: openConfirm, close: onConfirmClose }] = useDisclosure(false);
 
   const handleClearData = async () => {
@@ -109,6 +112,14 @@ export const SettingsPage = () => {
               </Box>
             </Stack>
           </Stack>
+        </Stack>
+        <Stack>
+          <ActionIcon
+            data-testid={setDataTestId('settings-page-close-button')}
+            onClick={() => navigate('/')}
+          >
+            <IconX />
+          </ActionIcon>
         </Stack>
       </Group>
     </>

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -581,7 +581,7 @@ export const theme = createTheme({
         },
         classNames: {
           content: 'bg-backgroundPrimary-light dark:bg-backgroundPrimary-dark rounded-2xl',
-          header: 'p-4',
+          header: 'p-4 bg-backgroundPrimary-light dark:bg-backgroundPrimary-dark',
         },
       },
     }),

--- a/tests/integration/script/script-explorer.spec.ts
+++ b/tests/integration/script/script-explorer.spec.ts
@@ -46,6 +46,7 @@ test('Select items in the query explorer list using Hotkeys', async ({
   await assertScriptNodesSelection([1]);
 
   // Select all items using ControlOrMeta + A
+  await clickScriptByIndex(1);
   await page.keyboard.press('ControlOrMeta+A');
   await assertScriptNodesSelection([0, 1, 2]);
 

--- a/tests/integration/settings/settings.spec.ts
+++ b/tests/integration/settings/settings.spec.ts
@@ -40,3 +40,18 @@ test('Open new script from settings page', async ({
   // Verify script editor is visible
   await expect(scriptEditor).toBeVisible();
 });
+
+test('Close settings page using close button', async ({ settingsPage, openSettings }) => {
+  // Open settings page
+  await openSettings();
+
+  // Verify the settings page is visible
+  await expect(settingsPage).toBeVisible();
+
+  // Close settings page using close button
+  const closeButton = settingsPage.getByTestId('settings-page-close-button');
+  await closeButton.click();
+
+  // Check settings page is not attached
+  await expect(settingsPage).not.toBeAttached();
+});


### PR DESCRIPTION
## Description

Minor UX fixes

## Related Issues

Closes: #34
Closes: #47
Closes: #21 

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
