### PR TITLE
[Bug]: Clear ExplorerTree selection on tab change

### DIFF
--- a/src/components/explorer-tree/explorer-tree.tsx
+++ b/src/components/explorer-tree/explorer-tree.tsx
@@ -45,8 +45,7 @@ type ExplorerTreeProps<NTypeToIdTypeMap extends Record<string, string>, ExtraT =
   onDeleteSelected: (ids: Iterable<NTypeToIdTypeMap[keyof NTypeToIdTypeMap]>) => void;
 
   /**
-   * If set, will be used to pass arbitrary extra data that is passed through to TreeNodeComponent
-   * for rendering.
+   * If set to false, the selection state will be cleared.
    */
   hasActiveElement: boolean;
 

--- a/src/components/explorer-tree/explorer-tree.tsx
+++ b/src/components/explorer-tree/explorer-tree.tsx
@@ -10,7 +10,7 @@ import {
 import { useHotkeys } from '@mantine/hooks';
 import { setDataTestId } from '@utils/test-id';
 import { cn } from '@utils/ui/styles';
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useMemo, useRef, useEffect } from 'react';
 
 import { RenderTreeNodePayload, TreeNodeMenuType, TreeNodeData } from './model';
 import { getFlattenNodes } from './utils/tree-manipulation';
@@ -45,6 +45,12 @@ type ExplorerTreeProps<NTypeToIdTypeMap extends Record<string, string>, ExtraT =
   onDeleteSelected: (ids: Iterable<NTypeToIdTypeMap[keyof NTypeToIdTypeMap]>) => void;
 
   /**
+   * If set, will be used to pass arbitrary extra data that is passed through to TreeNodeComponent
+   * for rendering.
+   */
+  hasActiveElement: boolean;
+
+  /**
    * Used to pass arbitrary extra data that is passed through to TreeNodeComponent
    * for rendering.
    */
@@ -58,6 +64,7 @@ export const ExplorerTree = <NTypeToIdTypeMap extends Record<string, string>, Ex
   TreeNodeComponent,
   onDeleteSelected,
   extraData,
+  hasActiveElement,
 }: ExplorerTreeProps<NTypeToIdTypeMap, ExtraT>) => {
   /**
    * Common hooks
@@ -157,6 +164,12 @@ export const ExplorerTree = <NTypeToIdTypeMap extends Record<string, string>, Ex
       },
     ],
   ]);
+
+  useEffect(() => {
+    if (!hasActiveElement) {
+      tree.clearSelected();
+    }
+  }, [hasActiveElement, tree]);
 
   return (
     <Stack

--- a/src/components/explorer-tree/explorer-tree.tsx
+++ b/src/components/explorer-tree/explorer-tree.tsx
@@ -168,7 +168,8 @@ export const ExplorerTree = <NTypeToIdTypeMap extends Record<string, string>, Ex
     if (!hasActiveElement) {
       tree.clearSelected();
     }
-  }, [hasActiveElement, tree]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasActiveElement]);
 
   return (
     <Stack

--- a/src/features/db-explorer/db-explorer.tsx
+++ b/src/features/db-explorer/db-explorer.tsx
@@ -22,7 +22,7 @@ import {
 import { copyToClipboard } from '@utils/clipboard';
 import { toDuckDBIdentifier } from '@utils/duckdb/identifier';
 import { getAttachedDBDataSourceName } from '@utils/navigation';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
 import { DbExplorerNode } from './db-explorer-node';
 import { DBExplorerNodeExtraType, DBExplorerNodeTypeToIdTypeMap } from './model';
@@ -278,8 +278,10 @@ export const DbExplorer = memo(() => {
   /**
    * Store access
    */
-  const activeTabId = useAppStore.use.activeTabId();
-  const tabs = useAppStore.use.tabs();
+  const hasActiveElement = useAppStore((state) => {
+    const activeTab = state.activeTabId && state.tabs.get(state.activeTabId);
+    return activeTab?.type === 'data-source' && activeTab?.dataSourceType === 'db';
+  });
   const attachedDBMap = useAttachedDBDataSourceMap();
   const attachedDBLocalEntriesMap = useAttachedDBLocalEntriesMap();
   const dataBaseMetadata = useAttachedDBMetadata();
@@ -381,11 +383,6 @@ export const DbExplorer = memo(() => {
 
     deleteDataSources(conn, dbIds);
   };
-
-  const hasActiveElement = useMemo(() => {
-    const activeTab = activeTabId && tabs.get(activeTabId);
-    return activeTab?.type === 'data-source' && activeTab?.dataSourceType === 'db';
-  }, [activeTabId, tabs]);
 
   return (
     <ExplorerTree<DBExplorerNodeTypeToIdTypeMap, DBExplorerNodeExtraType>

--- a/src/features/db-explorer/db-explorer.tsx
+++ b/src/features/db-explorer/db-explorer.tsx
@@ -14,6 +14,7 @@ import { useInitializedDuckDBConnectionPool } from '@features/duckdb-context/duc
 import { PersistentDataSourceId } from '@models/data-source';
 import { DBColumn, DBSchema, DBTableOrView, DBTableOrViewSchema } from '@models/db';
 import {
+  useAppStore,
   useAttachedDBDataSourceMap,
   useAttachedDBLocalEntriesMap,
   useAttachedDBMetadata,
@@ -21,7 +22,7 @@ import {
 import { copyToClipboard } from '@utils/clipboard';
 import { toDuckDBIdentifier } from '@utils/duckdb/identifier';
 import { getAttachedDBDataSourceName } from '@utils/navigation';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { DbExplorerNode } from './db-explorer-node';
 import { DBExplorerNodeExtraType, DBExplorerNodeTypeToIdTypeMap } from './model';
@@ -277,6 +278,8 @@ export const DbExplorer = memo(() => {
   /**
    * Store access
    */
+  const activeTabId = useAppStore.use.activeTabId();
+  const tabs = useAppStore.use.tabs();
   const attachedDBMap = useAttachedDBDataSourceMap();
   const attachedDBLocalEntriesMap = useAttachedDBLocalEntriesMap();
   const dataBaseMetadata = useAttachedDBMetadata();
@@ -379,6 +382,11 @@ export const DbExplorer = memo(() => {
     deleteDataSources(conn, dbIds);
   };
 
+  const hasActiveElement = useMemo(() => {
+    const activeTab = activeTabId && tabs.get(activeTabId);
+    return activeTab?.type === 'data-source' && activeTab?.dataSourceType === 'db';
+  }, [activeTabId, tabs]);
+
   return (
     <ExplorerTree<DBExplorerNodeTypeToIdTypeMap, DBExplorerNodeExtraType>
       nodes={dbObjectsTree}
@@ -387,6 +395,7 @@ export const DbExplorer = memo(() => {
       dataTestIdPrefix="db-explorer"
       TreeNodeComponent={DbExplorerNode}
       onDeleteSelected={handleDeleteSelected}
+      hasActiveElement={hasActiveElement}
     />
   );
 });

--- a/src/features/file-system-explorer/file-system-explorer.tsx
+++ b/src/features/file-system-explorer/file-system-explorer.tsx
@@ -41,8 +41,10 @@ export const FileSystemExplorer = memo(() => {
    * Store access
    */
 
-  // Read oly necessary sources
+  // Read only necessary sources
   const flatFileSources = useFlatFileDataSourceMap();
+  const activeTabId = useAppStore.use.activeTabId();
+  const tabs = useAppStore.use.tabs();
 
   // Create a map of all flat file sources by their related file ID
   const dataSourceByFileId: Map<LocalEntryId, AnyFlatFileDataSource> = new Map(
@@ -404,6 +406,11 @@ export const FileSystemExplorer = memo(() => {
     }
   };
 
+  const hasActiveElement = useMemo(() => {
+    const activeTab = activeTabId && tabs.get(activeTabId);
+    return activeTab?.type === 'data-source' && activeTab.dataSourceType === 'file';
+  }, [activeTabId, tabs]);
+
   return (
     <ExplorerTree<FSExplorerNodeTypeToIdTypeMap, FSExplorerNodeExtraType>
       nodes={fileSystemTree}
@@ -413,6 +420,7 @@ export const FileSystemExplorer = memo(() => {
       dataTestIdPrefix="file-system-explorer"
       TreeNodeComponent={FileSystemExplorerNode}
       onDeleteSelected={handleDeleteSelected}
+      hasActiveElement={hasActiveElement}
     />
   );
 });

--- a/src/features/file-system-explorer/file-system-explorer.tsx
+++ b/src/features/file-system-explorer/file-system-explorer.tsx
@@ -43,8 +43,10 @@ export const FileSystemExplorer = memo(() => {
 
   // Read only necessary sources
   const flatFileSources = useFlatFileDataSourceMap();
-  const activeTabId = useAppStore.use.activeTabId();
-  const tabs = useAppStore.use.tabs();
+  const hasActiveElement = useAppStore((state) => {
+    const activeTab = state.activeTabId && state.tabs.get(state.activeTabId);
+    return activeTab?.type === 'data-source' && activeTab.dataSourceType === 'file';
+  });
 
   // Create a map of all flat file sources by their related file ID
   const dataSourceByFileId: Map<LocalEntryId, AnyFlatFileDataSource> = new Map(
@@ -405,11 +407,6 @@ export const FileSystemExplorer = memo(() => {
       deleteLocalFileOrFolders(conn, folders);
     }
   };
-
-  const hasActiveElement = useMemo(() => {
-    const activeTab = activeTabId && tabs.get(activeTabId);
-    return activeTab?.type === 'data-source' && activeTab.dataSourceType === 'file';
-  }, [activeTabId, tabs]);
 
   return (
     <ExplorerTree<FSExplorerNodeTypeToIdTypeMap, FSExplorerNodeExtraType>

--- a/src/features/script-explorer/script-explorer.tsx
+++ b/src/features/script-explorer/script-explorer.tsx
@@ -12,7 +12,7 @@ import { SQLScriptId } from '@models/sql-script';
 import { useSqlScriptNameMap, useAppStore } from '@store/app-store';
 import { copyToClipboard } from '@utils/clipboard';
 import { createShareableScriptUrl } from '@utils/script-sharing';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
 import { ScrtiptNodeTypeToIdTypeMap } from './model';
 import { ScriptExplorerNode } from './script-explorer-node';
@@ -70,8 +70,11 @@ export const ScriptExplorer = memo(() => {
    * Global state
    */
   const sqlScripts = useSqlScriptNameMap();
-  const activeTabId = useAppStore.use.activeTabId();
-  const tabs = useAppStore.use.tabs();
+
+  const hasActiveElement = useAppStore((state) => {
+    const activeTab = state.activeTabId && state.tabs.get(state.activeTabId);
+    return activeTab?.type === 'script';
+  });
 
   /**
    * Consts
@@ -132,11 +135,6 @@ export const ScriptExplorer = memo(() => {
       // no children
     }),
   );
-
-  const hasActiveElement = useMemo(() => {
-    const activeTab = activeTabId && tabs.get(activeTabId);
-    return activeTab?.type === 'script';
-  }, [activeTabId, tabs]);
 
   return (
     <ExplorerTree<ScrtiptNodeTypeToIdTypeMap>

--- a/src/features/script-explorer/script-explorer.tsx
+++ b/src/features/script-explorer/script-explorer.tsx
@@ -12,7 +12,7 @@ import { SQLScriptId } from '@models/sql-script';
 import { useSqlScriptNameMap, useAppStore } from '@store/app-store';
 import { copyToClipboard } from '@utils/clipboard';
 import { createShareableScriptUrl } from '@utils/script-sharing';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { ScrtiptNodeTypeToIdTypeMap } from './model';
 import { ScriptExplorerNode } from './script-explorer-node';
@@ -70,6 +70,8 @@ export const ScriptExplorer = memo(() => {
    * Global state
    */
   const sqlScripts = useSqlScriptNameMap();
+  const activeTabId = useAppStore.use.activeTabId();
+  const tabs = useAppStore.use.tabs();
 
   /**
    * Consts
@@ -131,12 +133,18 @@ export const ScriptExplorer = memo(() => {
     }),
   );
 
+  const hasActiveElement = useMemo(() => {
+    const activeTab = activeTabId && tabs.get(activeTabId);
+    return activeTab?.type === 'script';
+  }, [activeTabId, tabs]);
+
   return (
     <ExplorerTree<ScrtiptNodeTypeToIdTypeMap>
       nodes={sqlScriptTree}
       dataTestIdPrefix="script-explorer"
       TreeNodeComponent={ScriptExplorerNode}
       onDeleteSelected={deleteSqlScripts}
+      hasActiveElement={hasActiveElement}
       extraData={undefined}
     />
   );

--- a/tests/integration/db-explorer/db-explorer.spec.ts
+++ b/tests/integration/db-explorer/db-explorer.spec.ts
@@ -1,0 +1,71 @@
+import { execSync } from 'child_process';
+
+import { expect, mergeTests } from '@playwright/test';
+
+import { test as dbExplorerTest } from '../fixtures/db-explorer';
+import { test as filePickerTest } from '../fixtures/file-picker';
+import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as globalHotkeyTest } from '../fixtures/global-hotkeys';
+import { test as baseTest } from '../fixtures/page';
+import { test as scriptExplorerTest } from '../fixtures/script-explorer';
+import { test as storageTest } from '../fixtures/storage';
+import { test as testTmpTest } from '../fixtures/test-tmp';
+import { isExplorerTreeNodeSelected } from '../fixtures/utils/explorer-tree';
+
+const test = mergeTests(
+  baseTest,
+  fileSystemExplorerTest,
+  scriptExplorerTest,
+  storageTest,
+  filePickerTest,
+  testTmpTest,
+  dbExplorerTest,
+  globalHotkeyTest,
+);
+
+test('DuckDB view should be deselected after creating script via spotlight', async ({
+  addFileButton,
+  storage,
+  filePicker,
+  testTmp,
+  openDatabaseExplorer,
+  assertDBExplorerItems,
+  clickDBByName,
+  pressNewScriptHotkey,
+  getDBNodeByName,
+}) => {
+  // Create a DuckDB database with a test view
+  const dbPath = testTmp.join('test_selection.duckdb');
+  execSync(`duckdb "${dbPath}" -c "CREATE VIEW test_view AS SELECT 1 AS value;"`);
+
+  // Upload and add the DuckDB file
+  await storage.uploadFile(dbPath, 'test_selection.duckdb');
+  await filePicker.selectFiles(['test_selection.duckdb']);
+  await addFileButton.click();
+
+  // Switch to DB Explorer and expand the database
+  await openDatabaseExplorer();
+  await assertDBExplorerItems(['test_selection']);
+  await clickDBByName('test_selection');
+
+  // Get the main schema node and click it to expand
+  const mainSchema = await getDBNodeByName('main');
+  await mainSchema.click();
+
+  // Check that the view is present
+  const viewNode = await getDBNodeByName('test_view');
+  await expect(viewNode).toBeVisible();
+
+  // Click the view to select it
+  await viewNode.click();
+
+  // Check that the view is selected
+  expect(await isExplorerTreeNodeSelected(viewNode)).toBe(true);
+
+  // Create a new script using spotlight without mouse interactions
+  // and verify file gets deselected
+  await pressNewScriptHotkey();
+
+  // Check that the view is deselected after creating the script
+  expect(await isExplorerTreeNodeSelected(viewNode)).toBe(false);
+});

--- a/tests/integration/file-explorer/file-explorer.spec.ts
+++ b/tests/integration/file-explorer/file-explorer.spec.ts
@@ -1,10 +1,12 @@
+import { execSync } from 'child_process';
+
 import { expect, mergeTests } from '@playwright/test';
 
 import { createFile } from '../../utils';
+import { test as dbExplorerTest } from '../fixtures/db-explorer';
 import { test as filePickerTest } from '../fixtures/file-picker';
 import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
 import { test as baseTest } from '../fixtures/page';
-import { test as scriptEditor } from '../fixtures/script-editor';
 import { test as scriptExplorerTest } from '../fixtures/script-explorer';
 import { test as spotlightTest } from '../fixtures/spotlight';
 import { test as storageTest } from '../fixtures/storage';
@@ -19,8 +21,8 @@ const test = mergeTests(
   filePickerTest,
   testTmpTest,
   fileSystemExplorerTest,
-  scriptEditor,
   spotlightTest,
+  dbExplorerTest,
 );
 
 test('File should be deselected after creating script from it', async ({
@@ -69,4 +71,116 @@ test('File should be deselected after creating script from it', async ({
 
   // Check that the file selection is cleared after creating script via spotlight
   await expect(fileNode).toHaveAttribute('data-selected', 'false');
+});
+
+test('DuckDB view should be deselected after creating script via spotlight', async ({
+  addFileButton,
+  storage,
+  filePicker,
+  testTmp,
+  openDatabaseExplorer,
+  assertDBExplorerItems,
+  clickDBByName,
+  getDBNodeByName,
+  createScriptViaSpotlight,
+}) => {
+  // Create a DuckDB database with a test view
+  const dbPath = testTmp.join('test_selection.duckdb');
+  execSync(`duckdb "${dbPath}" -c "CREATE VIEW test_view AS SELECT 1 AS value;"`);
+
+  // Upload and add the DuckDB file
+  await storage.uploadFile(dbPath, 'test_selection.duckdb');
+  await filePicker.selectFiles(['test_selection.duckdb']);
+  await addFileButton.click();
+
+  // Switch to DB Explorer and expand the database
+  await openDatabaseExplorer();
+  await assertDBExplorerItems(['test_selection']);
+  await clickDBByName('test_selection');
+
+  // Get the main schema node and click it to expand
+  const mainSchema = await getDBNodeByName('main');
+  await mainSchema.click();
+
+  // Check that the view is present
+  const viewNode = await getDBNodeByName('test_view');
+  await expect(viewNode).toBeVisible();
+
+  // Click the view to select it
+  await viewNode.click();
+
+  // Check that the view is selected (data-selected="true")
+  await expect(viewNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a new script using spotlight
+  await createScriptViaSpotlight();
+
+  // Check that the view is deselected after creating the script
+  await expect(viewNode).toHaveAttribute('data-selected', 'false');
+});
+
+test('Script should be deselected after opening the file', async ({
+  addFileButton,
+  storage,
+  filePicker,
+  testTmp,
+  assertFileExplorerItems,
+  clickFileByName,
+  getFileNodeByName,
+  getScriptNodeByName,
+  createScriptViaSpotlight,
+  openSpotlight,
+  page,
+  spotlight,
+}) => {
+  // Create and add a test file
+  const testFile = testTmp.join('test_selection.csv');
+  const testFileContent = 'col\ntest_value';
+  createFile(testFile, testFileContent);
+  await storage.uploadFile(testFile, 'test_selection.csv');
+  await filePicker.selectFiles(['test_selection.csv']);
+  await addFileButton.click();
+
+  // Verify the file was added
+  await assertFileExplorerItems(['test_selection']);
+
+  // Click on the file to select it
+  await clickFileByName('test_selection');
+
+  // Check that the file is selected (has data-selected="true")
+  const fileNode = await getFileNodeByName('test_selection');
+  // Select the file node
+  fileNode.click();
+  // Check that the file is selected (data-selected="true")
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a new script using spotlight and verify file gets deselected
+  await createScriptViaSpotlight();
+
+  // Check that the file selection is cleared after creating script via spotlight
+  await expect(fileNode).toHaveAttribute('data-selected', 'false');
+
+  await clickFileByName('test_selection');
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  const scriptNode = await getScriptNodeByName('query.sql');
+  scriptNode.click();
+
+  // Now test the case when searching for the file via spotlight
+  // click body
+  await page.click('body');
+  await openSpotlight({ trigger: 'hotkey' });
+
+  // Type the search term into spotlight
+  await page.getByTestId('spotlight-search').fill('test_selection');
+
+  // Wait for the search results to appear
+  // eslint-disable-next-line playwright/no-wait-for-selector
+  await page.waitForSelector('[data-testid^="spotlight-action-"]');
+
+  // Find and click on the matching result
+  await spotlight.getByText('test_selection', { exact: true }).click();
+
+  // Check that the file is deselected after opening it via spotlight
+  await expect(scriptNode).toHaveAttribute('data-selected', 'false');
 });

--- a/tests/integration/file-explorer/file-explorer.spec.ts
+++ b/tests/integration/file-explorer/file-explorer.spec.ts
@@ -1,0 +1,72 @@
+import { expect, mergeTests } from '@playwright/test';
+
+import { createFile } from '../../utils';
+import { test as filePickerTest } from '../fixtures/file-picker';
+import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as baseTest } from '../fixtures/page';
+import { test as scriptEditor } from '../fixtures/script-editor';
+import { test as scriptExplorerTest } from '../fixtures/script-explorer';
+import { test as spotlightTest } from '../fixtures/spotlight';
+import { test as storageTest } from '../fixtures/storage';
+import { test as tabTest } from '../fixtures/tab';
+import { test as testTmpTest } from '../fixtures/test-tmp';
+
+const test = mergeTests(
+  baseTest,
+  scriptExplorerTest,
+  tabTest,
+  storageTest,
+  filePickerTest,
+  testTmpTest,
+  fileSystemExplorerTest,
+  scriptEditor,
+  spotlightTest,
+);
+
+test('File should be deselected after creating script from it', async ({
+  addFileButton,
+  storage,
+  filePicker,
+  testTmp,
+  createScriptFromFileExplorer,
+  assertFileExplorerItems,
+  clickFileByName,
+  getFileNodeByName,
+  createScriptViaSpotlight,
+}) => {
+  // Create and add a test file
+  const testFile = testTmp.join('test_selection.csv');
+  const testFileContent = 'col\ntest_value';
+  createFile(testFile, testFileContent);
+  await storage.uploadFile(testFile, 'test_selection.csv');
+  await filePicker.selectFiles(['test_selection.csv']);
+  await addFileButton.click();
+
+  // Verify the file was added
+  await assertFileExplorerItems(['test_selection']);
+
+  // Click on the file to select it
+  await clickFileByName('test_selection');
+
+  // Check that the file is selected (has data-selected="true")
+  const fileNode = await getFileNodeByName('test_selection');
+  // Select the file node
+  fileNode.click();
+  // Check that the file is selected (data-selected="true")
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a script from the file
+  await createScriptFromFileExplorer('test_selection');
+  // Check that the file is now deselected (data-selected changed to "false" or is absent)
+  await expect(fileNode).toHaveAttribute('data-selected', 'false');
+
+  // Select the file again
+  await clickFileByName('test_selection');
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a new script using spotlight and verify file gets deselected
+  await createScriptViaSpotlight();
+
+  // Check that the file selection is cleared after creating script via spotlight
+  await expect(fileNode).toHaveAttribute('data-selected', 'false');
+});

--- a/tests/integration/file-explorer/file-explorer.spec.ts
+++ b/tests/integration/file-explorer/file-explorer.spec.ts
@@ -1,28 +1,23 @@
-import { execSync } from 'child_process';
-
 import { expect, mergeTests } from '@playwright/test';
 
 import { createFile } from '../../utils';
-import { test as dbExplorerTest } from '../fixtures/db-explorer';
 import { test as filePickerTest } from '../fixtures/file-picker';
 import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as globalHotkeyTest } from '../fixtures/global-hotkeys';
 import { test as baseTest } from '../fixtures/page';
 import { test as scriptExplorerTest } from '../fixtures/script-explorer';
-import { test as spotlightTest } from '../fixtures/spotlight';
 import { test as storageTest } from '../fixtures/storage';
-import { test as tabTest } from '../fixtures/tab';
 import { test as testTmpTest } from '../fixtures/test-tmp';
+import { isExplorerTreeNodeSelected } from '../fixtures/utils/explorer-tree';
 
 const test = mergeTests(
   baseTest,
   scriptExplorerTest,
-  tabTest,
   storageTest,
   filePickerTest,
   testTmpTest,
   fileSystemExplorerTest,
-  spotlightTest,
-  dbExplorerTest,
+  globalHotkeyTest,
 );
 
 test('File should be deselected after creating script from it', async ({
@@ -34,7 +29,8 @@ test('File should be deselected after creating script from it', async ({
   assertFileExplorerItems,
   clickFileByName,
   getFileNodeByName,
-  createScriptViaSpotlight,
+  assertScriptExplorerItems,
+  pressNewScriptHotkey,
 }) => {
   // Create and add a test file
   const testFile = testTmp.join('test_selection.csv');
@@ -47,140 +43,29 @@ test('File should be deselected after creating script from it', async ({
   // Verify the file was added
   await assertFileExplorerItems(['test_selection']);
 
-  // Click on the file to select it
-  await clickFileByName('test_selection');
-
   // Check that the file is selected (has data-selected="true")
   const fileNode = await getFileNodeByName('test_selection');
   // Select the file node
-  fileNode.click();
-  // Check that the file is selected (data-selected="true")
-  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+  await fileNode.click();
+  // Check that the file is selected
+  expect(await isExplorerTreeNodeSelected(fileNode)).toBe(true);
 
   // Create a script from the file
   await createScriptFromFileExplorer('test_selection');
-  // Check that the file is now deselected (data-selected changed to "false" or is absent)
-  await expect(fileNode).toHaveAttribute('data-selected', 'false');
+  // Check that the file is now deselected
+  expect(await isExplorerTreeNodeSelected(fileNode)).toBe(false);
 
   // Select the file again
   await clickFileByName('test_selection');
-  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+  expect(await isExplorerTreeNodeSelected(fileNode)).toBe(true);
 
-  // Create a new script using spotlight and verify file gets deselected
-  await createScriptViaSpotlight();
+  // Create a new script using spotlight without mouse interactions
+  // and verify file gets deselected
+  await pressNewScriptHotkey();
 
-  // Check that the file selection is cleared after creating script via spotlight
-  await expect(fileNode).toHaveAttribute('data-selected', 'false');
-});
+  // Check that we now have 2 scripts
+  await assertScriptExplorerItems(['query.sql', 'test_selection_query.sql']);
 
-test('DuckDB view should be deselected after creating script via spotlight', async ({
-  addFileButton,
-  storage,
-  filePicker,
-  testTmp,
-  openDatabaseExplorer,
-  assertDBExplorerItems,
-  clickDBByName,
-  getDBNodeByName,
-  createScriptViaSpotlight,
-}) => {
-  // Create a DuckDB database with a test view
-  const dbPath = testTmp.join('test_selection.duckdb');
-  execSync(`duckdb "${dbPath}" -c "CREATE VIEW test_view AS SELECT 1 AS value;"`);
-
-  // Upload and add the DuckDB file
-  await storage.uploadFile(dbPath, 'test_selection.duckdb');
-  await filePicker.selectFiles(['test_selection.duckdb']);
-  await addFileButton.click();
-
-  // Switch to DB Explorer and expand the database
-  await openDatabaseExplorer();
-  await assertDBExplorerItems(['test_selection']);
-  await clickDBByName('test_selection');
-
-  // Get the main schema node and click it to expand
-  const mainSchema = await getDBNodeByName('main');
-  await mainSchema.click();
-
-  // Check that the view is present
-  const viewNode = await getDBNodeByName('test_view');
-  await expect(viewNode).toBeVisible();
-
-  // Click the view to select it
-  await viewNode.click();
-
-  // Check that the view is selected (data-selected="true")
-  await expect(viewNode).toHaveAttribute('data-selected', 'true');
-
-  // Create a new script using spotlight
-  await createScriptViaSpotlight();
-
-  // Check that the view is deselected after creating the script
-  await expect(viewNode).toHaveAttribute('data-selected', 'false');
-});
-
-test('Script should be deselected after opening the file', async ({
-  addFileButton,
-  storage,
-  filePicker,
-  testTmp,
-  assertFileExplorerItems,
-  clickFileByName,
-  getFileNodeByName,
-  getScriptNodeByName,
-  createScriptViaSpotlight,
-  openSpotlight,
-  page,
-  spotlight,
-}) => {
-  // Create and add a test file
-  const testFile = testTmp.join('test_selection.csv');
-  const testFileContent = 'col\ntest_value';
-  createFile(testFile, testFileContent);
-  await storage.uploadFile(testFile, 'test_selection.csv');
-  await filePicker.selectFiles(['test_selection.csv']);
-  await addFileButton.click();
-
-  // Verify the file was added
-  await assertFileExplorerItems(['test_selection']);
-
-  // Click on the file to select it
-  await clickFileByName('test_selection');
-
-  // Check that the file is selected (has data-selected="true")
-  const fileNode = await getFileNodeByName('test_selection');
-  // Select the file node
-  fileNode.click();
-  // Check that the file is selected (data-selected="true")
-  await expect(fileNode).toHaveAttribute('data-selected', 'true');
-
-  // Create a new script using spotlight and verify file gets deselected
-  await createScriptViaSpotlight();
-
-  // Check that the file selection is cleared after creating script via spotlight
-  await expect(fileNode).toHaveAttribute('data-selected', 'false');
-
-  await clickFileByName('test_selection');
-  await expect(fileNode).toHaveAttribute('data-selected', 'true');
-
-  const scriptNode = await getScriptNodeByName('query.sql');
-  scriptNode.click();
-
-  // Now test the case when searching for the file via spotlight
-  // click body
-  await page.click('body');
-  await openSpotlight({ trigger: 'hotkey' });
-
-  // Type the search term into spotlight
-  await page.getByTestId('spotlight-search').fill('test_selection');
-
-  // Wait for the search results to appear
-  // eslint-disable-next-line playwright/no-wait-for-selector
-  await page.waitForSelector('[data-testid^="spotlight-action-"]');
-
-  // Find and click on the matching result
-  await spotlight.getByText('test_selection', { exact: true }).click();
-
-  // Check that the file is deselected after opening it via spotlight
-  await expect(scriptNode).toHaveAttribute('data-selected', 'false');
+  // Check that the file selection is cleared after creating script via hotkey
+  expect(await isExplorerTreeNodeSelected(fileNode)).toBe(false);
 });

--- a/tests/integration/fixtures/file-system-explorer.ts
+++ b/tests/integration/fixtures/file-system-explorer.ts
@@ -50,7 +50,7 @@ type FileSystemExplorerFixtures = {
   createScriptFromFileExplorer: (fileName: string) => Promise<void>;
 };
 
-const FILE_SYSTEM_EXPLORER_DATA_TESTID_PREFIX = 'file-system-explorer';
+export const FILE_SYSTEM_EXPLORER_DATA_TESTID_PREFIX = 'file-system-explorer';
 
 export const test = base.extend<FileSystemExplorerFixtures>({
   fileSystemExplorer: async ({ page }, use) => {

--- a/tests/integration/fixtures/global-hotkeys.ts
+++ b/tests/integration/fixtures/global-hotkeys.ts
@@ -1,0 +1,71 @@
+import { test as base } from '@playwright/test';
+
+type GlobalHotkeyFixtures = {
+  /**
+   * Press the keyboard shortcut to open spotlight menu (Ctrl+K)
+   */
+  pressSpotlightHotkey: () => Promise<void>;
+
+  /**
+   * Press the keyboard shortcut to create a new script (Alt+N)
+   */
+  pressNewScriptHotkey: () => Promise<void>;
+
+  /**
+   * Press the keyboard shortcut to add a file (Ctrl+F)
+   */
+  pressAddFileHotkey: () => Promise<void>;
+
+  /**
+   * Press the keyboard shortcut to add a DuckDB file (Ctrl+D)
+   */
+  pressAddDuckDBHotkey: () => Promise<void>;
+
+  /**
+   * Press the keyboard shortcut to import SQL files (Ctrl+I)
+   */
+  pressImportSQLHotkey: () => Promise<void>;
+
+  /**
+   * Press the keyboard shortcut to add a folder (Alt+Mod+F)
+   */
+  pressAddFolderHotkey: () => Promise<void>;
+};
+
+export const test = base.extend<GlobalHotkeyFixtures>({
+  pressSpotlightHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('ControlOrMeta+KeyK');
+    });
+  },
+
+  pressNewScriptHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('Alt+KeyN');
+    });
+  },
+
+  pressAddFileHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('ControlOrMeta+KeyF');
+    });
+  },
+
+  pressAddDuckDBHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('ControlOrMeta+KeyD');
+    });
+  },
+
+  pressImportSQLHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('ControlOrMeta+KeyI');
+    });
+  },
+
+  pressAddFolderHotkey: async ({ page }, use) => {
+    await use(async () => {
+      await page.keyboard.press('Alt+ControlOrMeta+KeyF');
+    });
+  },
+});

--- a/tests/integration/fixtures/script-explorer.ts
+++ b/tests/integration/fixtures/script-explorer.ts
@@ -18,7 +18,7 @@ import {
 
 type ScriptExplorerFixtures = {
   scriptExplorer: Locator;
-  createScriptAndSwitchToItsTab: () => Promise<void>;
+  createScriptAndSwitchToItsTab: () => Promise<Locator>;
   openScriptFromExplorer: (scriptName: string) => Promise<void>;
   getAllScriptNodes: () => Promise<Locator>;
   getScriptNodeByName: (scriptName: string) => Promise<Locator>;
@@ -50,7 +50,7 @@ export const test = base.extend<ScriptExplorerFixtures>({
   },
 
   createScriptAndSwitchToItsTab: async ({ page, getAllScriptNodes, getScriptNodeById }, use) => {
-    await use(async () => {
+    await use(async (): Promise<Locator> => {
       const scriptNodes = await getAllScriptNodes();
 
       // Save existing script node IDs
@@ -78,8 +78,10 @@ export const test = base.extend<ScriptExplorerFixtures>({
       const newScriptNode = await getScriptNodeById(newScriptNodeId);
 
       // Check that it has the selected data attribute. This assumes that
-      // tab is open and avoids dpending this test on tab fixtures.
-      await expect(newScriptNode).toHaveAttribute('data-selected', 'true');
+      // tab is open and avoids depending this test on tab fixtures.
+      expect(await isExplorerTreeNodeSelected(newScriptNode)).toBe(true);
+
+      return newScriptNode;
     });
   },
 

--- a/tests/integration/fixtures/spotlight.ts
+++ b/tests/integration/fixtures/spotlight.ts
@@ -1,8 +1,12 @@
 import { test as base, expect, Locator } from '@playwright/test';
 
+type OpenSpotlightProps = {
+  trigger: 'click' | 'hotkey';
+};
+
 type SpotlightFixtures = {
   spotlight: Locator;
-  openSpotlight: () => Promise<Locator>;
+  openSpotlight: (v: OpenSpotlightProps) => Promise<Locator>;
   createScriptViaSpotlight: () => Promise<void>;
   openSettingsViaSpotlight: () => Promise<void>;
   addDirectoryViaSpotlight: () => Promise<void>;
@@ -15,12 +19,16 @@ export const test = base.extend<SpotlightFixtures>({
   },
 
   openSpotlight: async ({ page, spotlight }, use) => {
-    await use(async () => {
+    await use(async (props) => {
       // Verify spotlight is not visible
       await expect(spotlight).toBeHidden();
 
       // Open spotlight menu using trigger
-      await page.getByTestId('spotlight-trigger-input').click();
+      if (props.trigger === 'hotkey') {
+        await page.keyboard.press('ControlOrMeta+k');
+      } else {
+        await page.getByTestId('spotlight-trigger-input').click();
+      }
 
       // Verify spotlight is visible
       await expect(spotlight).toBeVisible();
@@ -31,7 +39,7 @@ export const test = base.extend<SpotlightFixtures>({
 
   createScriptViaSpotlight: async ({ openSpotlight }, use) => {
     await use(async () => {
-      const spotlightRoot = await openSpotlight();
+      const spotlightRoot = await openSpotlight({ trigger: 'click' });
 
       // Create new query through spotlight
       await spotlightRoot.getByTestId('spotlight-action-create-new-script').click();
@@ -43,7 +51,7 @@ export const test = base.extend<SpotlightFixtures>({
 
   openSettingsViaSpotlight: async ({ openSpotlight }, use) => {
     await use(async () => {
-      const spotlightRoot = await openSpotlight();
+      const spotlightRoot = await openSpotlight({ trigger: 'click' });
 
       // Open settings through spotlight
       await spotlightRoot.getByTestId('spotlight-action-settings').click();
@@ -55,7 +63,7 @@ export const test = base.extend<SpotlightFixtures>({
 
   addDirectoryViaSpotlight: async ({ openSpotlight }, use) => {
     await use(async () => {
-      const spotlightRoot = await openSpotlight();
+      const spotlightRoot = await openSpotlight({ trigger: 'click' });
 
       // Add folder through spotlight
       await spotlightRoot.getByTestId('spotlight-action-add-folder').click();
@@ -67,7 +75,7 @@ export const test = base.extend<SpotlightFixtures>({
 
   openImportSharedScriptModalViaSpotlight: async ({ openSpotlight }, use) => {
     await use(async () => {
-      const spotlightRoot = await openSpotlight();
+      const spotlightRoot = await openSpotlight({ trigger: 'click' });
 
       // Share script through spotlight
       await spotlightRoot.getByTestId('spotlight-action-import-script-from-url').click();

--- a/tests/integration/fixtures/spotlight.ts
+++ b/tests/integration/fixtures/spotlight.ts
@@ -1,17 +1,72 @@
-import { test as base, expect, Locator } from '@playwright/test';
+import { test as base, expect, Locator, Page } from '@playwright/test';
 
 type OpenSpotlightProps = {
-  trigger: 'click' | 'hotkey';
+  trigger?: 'click' | 'hotkey';
+};
+
+type SpotlightActionProps = {
+  trigger?: 'mouse' | 'keyboard';
 };
 
 type SpotlightFixtures = {
   spotlight: Locator;
-  openSpotlight: (v: OpenSpotlightProps) => Promise<Locator>;
-  createScriptViaSpotlight: () => Promise<void>;
-  openSettingsViaSpotlight: () => Promise<void>;
-  addDirectoryViaSpotlight: () => Promise<void>;
-  openImportSharedScriptModalViaSpotlight: () => Promise<void>;
+  openSpotlight: (v?: OpenSpotlightProps) => Promise<Locator>;
+  createScriptViaSpotlight: (v?: SpotlightActionProps) => Promise<void>;
+  openSettingsViaSpotlight: (v?: SpotlightActionProps) => Promise<void>;
+  addDirectoryViaSpotlight: (v?: SpotlightActionProps) => Promise<void>;
+  openImportSharedScriptModalViaSpotlight: (v?: SpotlightActionProps) => Promise<void>;
 };
+
+async function selectSpotlightActionByKeyboard(
+  page: Page,
+  spotlightRoot: Locator,
+  spotlightAction: Locator,
+) {
+  // get the total count of spotlight actions to avoid infinite loop
+  const spotlightActionsCount = await spotlightRoot.getByTestId(/^spotlight-action-.*/).count();
+
+  // Select the action using arrow keys
+  let i = 0;
+  while (i <= spotlightActionsCount) {
+    await page.keyboard.press('ArrowDown');
+
+    const isActionSelected = await spotlightAction.evaluate((action) => {
+      return action.getAttribute('data-selected') === 'true';
+    });
+
+    if (isActionSelected) {
+      return;
+    }
+    i += 1;
+  }
+
+  throw new Error('Spotlight action not found');
+}
+
+async function triggerSpotlightAction(
+  page: Page,
+  openSpotlight: (v?: OpenSpotlightProps) => Promise<Locator>,
+  actionId: string,
+  props?: SpotlightActionProps,
+) {
+  const useKeyoardOnly = props?.trigger === 'keyboard';
+
+  const spotlightRoot = await openSpotlight({ trigger: useKeyoardOnly ? 'hotkey' : 'click' });
+
+  // Create new query through spotlight
+  const spotlightAction = spotlightRoot.getByTestId(`spotlight-action-${actionId}`);
+
+  // Perform action using mouse or keyboard
+  if (useKeyoardOnly) {
+    await selectSpotlightActionByKeyboard(page, spotlightRoot, spotlightAction);
+    await page.keyboard.press('Enter');
+  } else {
+    await spotlightAction.click();
+  }
+
+  // Verify spotlight is closed after performing action
+  await expect(spotlightRoot).toBeHidden();
+}
 
 export const test = base.extend<SpotlightFixtures>({
   spotlight: async ({ page }, use) => {
@@ -24,7 +79,7 @@ export const test = base.extend<SpotlightFixtures>({
       await expect(spotlight).toBeHidden();
 
       // Open spotlight menu using trigger
-      if (props.trigger === 'hotkey') {
+      if (props?.trigger === 'hotkey') {
         await page.keyboard.press('ControlOrMeta+k');
       } else {
         await page.getByTestId('spotlight-trigger-input').click();
@@ -37,51 +92,27 @@ export const test = base.extend<SpotlightFixtures>({
     });
   },
 
-  createScriptViaSpotlight: async ({ openSpotlight }, use) => {
-    await use(async () => {
-      const spotlightRoot = await openSpotlight({ trigger: 'click' });
-
-      // Create new query through spotlight
-      await spotlightRoot.getByTestId('spotlight-action-create-new-script').click();
-
-      // Verify spotlight is closed after creating query
-      await expect(spotlightRoot).toBeHidden();
+  createScriptViaSpotlight: async ({ page, openSpotlight }, use) => {
+    await use(async (props) => {
+      await triggerSpotlightAction(page, openSpotlight, 'create-new-script', props);
     });
   },
 
-  openSettingsViaSpotlight: async ({ openSpotlight }, use) => {
-    await use(async () => {
-      const spotlightRoot = await openSpotlight({ trigger: 'click' });
-
-      // Open settings through spotlight
-      await spotlightRoot.getByTestId('spotlight-action-settings').click();
-
-      // Verify spotlight is closed after opening settings
-      await expect(spotlightRoot).toBeHidden();
+  openSettingsViaSpotlight: async ({ page, openSpotlight }, use) => {
+    await use(async (props) => {
+      await triggerSpotlightAction(page, openSpotlight, 'settings', props);
     });
   },
 
-  addDirectoryViaSpotlight: async ({ openSpotlight }, use) => {
-    await use(async () => {
-      const spotlightRoot = await openSpotlight({ trigger: 'click' });
-
-      // Add folder through spotlight
-      await spotlightRoot.getByTestId('spotlight-action-add-folder').click();
-
-      // Verify spotlight is closed after adding directory
-      await expect(spotlightRoot).toBeHidden();
+  addDirectoryViaSpotlight: async ({ page, openSpotlight }, use) => {
+    await use(async (props) => {
+      await triggerSpotlightAction(page, openSpotlight, 'add-folder', props);
     });
   },
 
-  openImportSharedScriptModalViaSpotlight: async ({ openSpotlight }, use) => {
-    await use(async () => {
-      const spotlightRoot = await openSpotlight({ trigger: 'click' });
-
-      // Share script through spotlight
-      await spotlightRoot.getByTestId('spotlight-action-import-script-from-url').click();
-
-      // Verify spotlight is closed after sharing script
-      await expect(spotlightRoot).toBeHidden();
+  openImportSharedScriptModalViaSpotlight: async ({ page, openSpotlight }, use) => {
+    await use(async (props) => {
+      await triggerSpotlightAction(page, openSpotlight, 'import-script-from-url', props);
     });
   },
 });

--- a/tests/integration/script/script-explorer.spec.ts
+++ b/tests/integration/script/script-explorer.spec.ts
@@ -1,11 +1,27 @@
 import { expect, mergeTests } from '@playwright/test';
 
+import { createFile } from '../../utils';
+import { test as filePickerTest } from '../fixtures/file-picker';
+import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
 import { test as baseTest } from '../fixtures/page';
-import { test as scriptEditorTest } from '../fixtures/script-editor';
+import { test as scriptEditor } from '../fixtures/script-editor';
 import { test as scriptExplorerTest } from '../fixtures/script-explorer';
+import { test as spotlightTest } from '../fixtures/spotlight';
+import { test as storageTest } from '../fixtures/storage';
 import { test as tabTest } from '../fixtures/tab';
+import { test as testTmpTest } from '../fixtures/test-tmp';
 
-const test = mergeTests(baseTest, scriptExplorerTest, tabTest, scriptEditorTest);
+const test = mergeTests(
+  baseTest,
+  scriptExplorerTest,
+  tabTest,
+  storageTest,
+  filePickerTest,
+  testTmpTest,
+  fileSystemExplorerTest,
+  scriptEditor,
+  spotlightTest,
+);
 
 test('Switch between tabs using script explorer', async ({
   createScriptAndSwitchToItsTab,
@@ -101,4 +117,52 @@ test('Create new script with Alt+N hotkey', async ({
 
   // Verify that the new script editor is empty
   await expect(await getScriptEditorContent()).toContainText('');
+});
+
+test('File should be deselected after creating script from it', async ({
+  addFileButton,
+  storage,
+  filePicker,
+  testTmp,
+  createScriptFromFileExplorer,
+  assertFileExplorerItems,
+  clickFileByName,
+  getFileNodeByName,
+  createScriptViaSpotlight,
+}) => {
+  // Create and add a test file
+  const testFile = testTmp.join('test_selection.csv');
+  const testFileContent = 'col\ntest_value';
+  createFile(testFile, testFileContent);
+  await storage.uploadFile(testFile, 'test_selection.csv');
+  await filePicker.selectFiles(['test_selection.csv']);
+  await addFileButton.click();
+
+  // Verify the file was added
+  await assertFileExplorerItems(['test_selection']);
+
+  // Click on the file to select it
+  await clickFileByName('test_selection');
+
+  // Check that the file is selected (has data-selected="true")
+  const fileNode = await getFileNodeByName('test_selection');
+  // Select the file node
+  fileNode.click();
+  // Check that the file is selected (data-selected="true")
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a script from the file
+  await createScriptFromFileExplorer('test_selection');
+  // Check that the file is now deselected (data-selected changed to "false" or is absent)
+  await expect(fileNode).toHaveAttribute('data-selected', 'false');
+
+  // Select the file again
+  await clickFileByName('test_selection');
+  await expect(fileNode).toHaveAttribute('data-selected', 'true');
+
+  // Create a new script using spotlight and verify file gets deselected
+  await createScriptViaSpotlight();
+
+  // Check that the file selection is cleared after creating script via spotlight
+  await expect(fileNode).toHaveAttribute('data-selected', 'false');
 });

--- a/tests/integration/script/script-explorer.spec.ts
+++ b/tests/integration/script/script-explorer.spec.ts
@@ -3,6 +3,7 @@ import { expect, mergeTests } from '@playwright/test';
 import { createFile } from '../../utils';
 import { test as filePickerTest } from '../fixtures/file-picker';
 import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as globalHotkeyTest } from '../fixtures/global-hotkeys';
 import { test as baseTest } from '../fixtures/page';
 import { test as scriptEditor } from '../fixtures/script-editor';
 import { test as scriptExplorerTest } from '../fixtures/script-explorer';
@@ -13,14 +14,15 @@ import { test as testTmpTest } from '../fixtures/test-tmp';
 
 const test = mergeTests(
   baseTest,
-  scriptExplorerTest,
-  tabTest,
-  storageTest,
   filePickerTest,
-  testTmpTest,
   fileSystemExplorerTest,
+  globalHotkeyTest,
   scriptEditor,
+  scriptExplorerTest,
   spotlightTest,
+  storageTest,
+  tabTest,
+  testTmpTest,
 );
 
 test('Switch between tabs using script explorer', async ({
@@ -94,12 +96,12 @@ test('Select items in the query explorer list using Hotkeys', async ({
   await assertScriptNodesSelection([1]);
 });
 
-test('Create new script with Alt+N hotkey', async ({
+test('Create new script with hotkey', async ({
   createScriptAndSwitchToItsTab,
-  page,
   scriptEditorContent,
   assertScriptExplorerItems,
   getScriptEditorContent,
+  pressNewScriptHotkey,
 }) => {
   // Create initial script tab
   await createScriptAndSwitchToItsTab();
@@ -109,8 +111,8 @@ test('Create new script with Alt+N hotkey', async ({
   await editor.fill('select');
   await expect(editor).toContainText('select');
 
-  // Press Alt+N (Option+N on Mac) to create a new script
-  await page.keyboard.press('Alt+n');
+  // Press hotkey to create a new script
+  await pressNewScriptHotkey();
 
   // Verify that a new script named "query_1.sql" appears in the explorer
   await assertScriptExplorerItems(['query.sql', 'query_1.sql']);

--- a/tests/integration/spotlight/spotlight.spec.ts
+++ b/tests/integration/spotlight/spotlight.spec.ts
@@ -9,7 +9,7 @@ const test = mergeTests(baseTest, spotlightTest, tabTest, scriptEditorTest);
 
 test('Long action names are truncated in spotlight results', async ({ page, openSpotlight }) => {
   // Open spotlight menu
-  await openSpotlight();
+  await openSpotlight({ trigger: 'click' });
 
   // Create a long text of exactly 75 characters
   const longActionName =


### PR DESCRIPTION
## Description

Fixed select clearing in the explorer when selecting an item from another explorer

## Related Issues

Closes #26 

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
