### PR TITLE
[UX] Improve how and when loading state is shown and query cancellation behavior

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Build
-        run: yarn build
+      - name: Build (with PWA disabled for Docker)
+        run: DOCKER_BUILD=true yarn build
 
       # Build Docker image
       - name: Set up Docker Buildx

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ docker run -d -p 4173:80 --name pondpilot ghcr.io/pondpilot/pondpilot:latest
 
 Visit `http://localhost:4173` in your browser to access the app.
 
+> **Note:** PWA and offline mode is disabled for the Docker version to avoid conflicts with other apps serving on localhost.
+
 #### Using Yarn
 
 Alternatively, you can build & run PondPilot using Yarn:

--- a/justfile
+++ b/justfile
@@ -9,11 +9,11 @@ default:
 docker-build:
     corepack enable
     yarn install --immutable
-    yarn build
-    docker build -t pondpilot:latest -f docker/Dockerfile .
+    DOCKER_BUILD=true yarn build
+    docker build -t pondpilot:latest -f docker/Dockerfile --load .
 
 docker-run:
-    docker run -d -p 4173:80 --name pondpilot pondpilot:latest
+    docker run --rm -d -p 4173:80 --name pondpilot pondpilot:latest
 
 docker-stop:
     docker stop pondpilot

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "yarn build --mode int-test-build && playwright test",
     "test:unit": "jest",
     "test:all": "yarn test:unit && yarn test",
-    "preview": "tsc && vite build && vite preview",
+    "preview": "yarn build --mode int-test-build && vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "yarn lint:eslint && yarn lint:stylelint",
     "lint:fix": "yarn lint:eslint:fix && yarn lint:stylelint:fix",

--- a/src/components/data-loading-overlay/data-loading-overlay.tsx
+++ b/src/components/data-loading-overlay/data-loading-overlay.tsx
@@ -1,5 +1,8 @@
+import { HotkeyPill } from '@components/hotkey-pill';
 import { LoadingOverlay } from '@components/loading-overlay';
-import { Stack, Loader, Button, Text } from '@mantine/core';
+import { useOsModifierIcon } from '@hooks/use-os-modifier-icon';
+import { Stack, Loader, Button, Text, Group } from '@mantine/core';
+import { useHotkeys } from '@mantine/hooks';
 
 interface DataLoadingOverlayProps {
   title: string;
@@ -7,24 +10,42 @@ interface DataLoadingOverlayProps {
   visible: boolean;
 }
 
-export const DataLoadingOverlay = ({ onCancel, visible, title }: DataLoadingOverlayProps) => (
-  <LoadingOverlay visible={visible}>
-    <Stack align="center" gap={4} bg="background-primary" className="p-8 pt-4 rounded-2xl">
-      <Loader size={24} color="text-secondary" />
-      <Text c="text-primary" className="text-2xl font-medium">
-        {title}
-      </Text>
-      <span className="text-textSecondary-light dark:text-textSecondary-dark font-medium">
-        Press{' '}
-        <Button
-          c="text-primary"
-          onClick={onCancel}
-          className="bg-backgroundSecondary-light dark:bg-backgroundSecondary-dark hover:bg-backgroundTertiary-light dark:hover:bg-backgroundTertiary-dark"
-        >
-          Cancel
-        </Button>{' '}
-        or ⌥ Q to abort processing
-      </span>
-    </Stack>
-  </LoadingOverlay>
-);
+export const DataLoadingOverlay = ({ onCancel, visible, title }: DataLoadingOverlayProps) => {
+  const { option } = useOsModifierIcon();
+
+  useHotkeys([
+    [
+      'Alt+Q',
+      () => {
+        if (visible) {
+          onCancel();
+        }
+      },
+    ],
+  ]);
+
+  return (
+    <LoadingOverlay visible={visible}>
+      <Stack align="center" gap={4} bg="background-primary" className="p-8 pt-4 rounded-2xl">
+        <Loader size={24} color="text-secondary" />
+        <Text c="text-primary" className="text-2xl font-medium">
+          {title}
+        </Text>
+        <span className="text-textSecondary-light dark:text-textSecondary-dark font-medium">
+          Press{' '}
+          <Group align="center" className="inline-flex">
+            <Button
+              c="text-primary"
+              onClick={onCancel}
+              className="bg-backgroundSecondary-light dark:bg-backgroundSecondary-dark hover:bg-backgroundTertiary-light dark:hover:bg-backgroundTertiary-dark"
+            >
+              Cancel
+            </Button>{' '}
+            or <HotkeyPill variant="secondary" value={[option, 'Q']} />
+          </Group>{' '}
+          to abort processing
+        </span>
+      </Stack>
+    </LoadingOverlay>
+  );
+};

--- a/src/components/table/components/thead-cell/thead-cell.tsx
+++ b/src/components/table/components/thead-cell/thead-cell.tsx
@@ -63,19 +63,23 @@ const THeadTitle = ({
         {header.isPlaceholder ? null : columnName}
       </Text>
       {!isIndex && (
-        <div>
+        <div
+          className={cn(
+            'p-2 -m-2', // Add padding and negative margin to increase click area without changing layout
+            !isNumber && 'ml-auto',
+          )}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            onSort?.(columnName);
+          }}
+        >
           <IconTriangleInvertedFilled
             size={8}
-            onMouseDown={(e) => {
-              e.stopPropagation();
-              onSort?.(columnName);
-            }}
             className={cn(
               'opacity-0 text-iconDefault-light dark:text-iconDefault-dark',
               sort?.column === columnName && 'opacity-100',
               'group-hover:opacity-100',
               sort?.order === 'asc' && sort?.column === columnName && 'rotate-180',
-              !isNumber && 'ml-auto',
               (isSelected || !onSort) && 'text-iconDisabled',
             )}
           />

--- a/src/features/tab-view/components/data-view-info-pane/data-view-info-pane.tsx
+++ b/src/features/tab-view/components/data-view-info-pane/data-view-info-pane.tsx
@@ -5,7 +5,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { DataAdapterApi } from '@models/data-adapter';
 import { TabId, TabType } from '@models/tab';
 import { useAppStore } from '@store/app-store';
-import { IconX, IconCopy } from '@tabler/icons-react';
+import { IconX, IconCopy, IconRefresh } from '@tabler/icons-react';
 import { getTabName } from '@utils/navigation';
 import { setDataTestId } from '@utils/test-id';
 import { assertNeverValueType } from '@utils/typing';
@@ -61,7 +61,8 @@ export const DataViewInfoPane = ({ dataAdapter, tabType, tabId }: DataViewInfoPa
   const handleTableCopyClick = async () => {
     copyTableColumns({
       columns: dataAdapter.currentSchema,
-      dataAdapter,
+      currentSchema: dataAdapter.currentSchema,
+      getAllTableData: dataAdapter.getAllTableData,
     });
   };
 
@@ -147,6 +148,11 @@ export const DataViewInfoPane = ({ dataAdapter, tabType, tabId }: DataViewInfoPa
         {showCancelButton && (
           <ActionIcon size={16} onClick={dataAdapter.cancelDataRead}>
             <IconX />
+          </ActionIcon>
+        )}
+        {hasDataSourceError && (
+          <ActionIcon size={16} onClick={dataAdapter.reset}>
+            <IconRefresh />
           </ActionIcon>
         )}
       </Group>

--- a/src/features/tab-view/components/reset-button.tsx
+++ b/src/features/tab-view/components/reset-button.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@mantine/core';
+import { setDataTestId } from '@utils/test-id';
+
+export const DataViewRestartReadButton = ({
+  onClick,
+}: {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}) => (
+  <Button
+    onClick={onClick}
+    data-testid={setDataTestId('data-view-reset-button')}
+    color="background-accent"
+    className="rounded-full px-3"
+  >
+    Restart
+  </Button>
+);

--- a/src/features/tab-view/hooks/use-data-adapter-queries.ts
+++ b/src/features/tab-view/hooks/use-data-adapter-queries.ts
@@ -77,6 +77,9 @@ export const useDataAdapterQueries = ({
           internalErrors: [`Unknown tab type: ${tab.type}`],
         };
     }
+    // we need sourceVersion to be a dependency, because it allows us to re-create the queries
+    // when the script is re-executed, even if the data source is "the same"
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, pool, dataSource, sourceFile, sourceVersion]);
 
   return ret;

--- a/src/features/tab-view/utils.ts
+++ b/src/features/tab-view/utils.ts
@@ -18,19 +18,24 @@ function prepCopyTargetText({
 
 interface CopyTableColumnsProps {
   columns: DBColumn[];
-  dataAdapter: DataAdapterApi;
+  currentSchema: DataAdapterApi['currentSchema'];
+  getAllTableData: DataAdapterApi['getAllTableData'];
 }
 
 /**
  * Handle copy selected columns
  */
-export const copyTableColumns = async ({ columns, dataAdapter }: CopyTableColumnsProps) => {
+export const copyTableColumns = async ({
+  columns,
+  currentSchema,
+  getAllTableData,
+}: CopyTableColumnsProps) => {
   // We do not want to call API if no columns are selected
   if (!columns.length) {
     return;
   }
 
-  const copyTargetText = prepCopyTargetText({ columns, tableSchema: dataAdapter.currentSchema });
+  const copyTargetText = prepCopyTargetText({ columns, tableSchema: currentSchema });
 
   const notificationId = showSuccess({
     title: `Copying ${copyTargetText} to clipboard...`,
@@ -40,7 +45,7 @@ export const copyTableColumns = async ({ columns, dataAdapter }: CopyTableColumn
     color: 'text-accent',
   });
   try {
-    const data = await dataAdapter.getAllTableData(columns);
+    const data = await getAllTableData(columns);
 
     const formattedRows = getStringifyTypedRows(data, columns, '');
     const tsvRowsData = formatTableData(formattedRows, '\t');

--- a/src/models/data-adapter.ts
+++ b/src/models/data-adapter.ts
@@ -157,6 +157,12 @@ export interface DataAdapterApi {
   dataReadCancelled: boolean;
 
   /**
+   * Function to reset the data adapter, i.e. re-create data
+   * connection and drop any error, cancellation state.
+   */
+  reset: () => Promise<void>;
+
+  /**
    * Function to retrieve available data & schema for the given range
    *
    * NOTE: this may return a different range of rows than requested
@@ -240,7 +246,10 @@ export interface DataAdapterQueries {
    *
    * If both are missing it essentially means no data source exists.
    */
-  getSortableReader?: (sort: ColumnSortSpecList) => Promise<AsyncDuckDBPooledStreamReader<any>>;
+  getSortableReader?: (
+    sort: ColumnSortSpecList,
+    abortSignal: AbortSignal,
+  ) => Promise<AsyncDuckDBPooledStreamReader<any> | null>;
 
   /**
    * Returns a streaming reader.
@@ -250,7 +259,7 @@ export interface DataAdapterQueries {
    *
    * If both are missing it essentially means no data source exists.
    */
-  getReader?: () => Promise<AsyncDuckDBPooledStreamReader<any>>;
+  getReader?: (abortSignal: AbortSignal) => Promise<AsyncDuckDBPooledStreamReader<any> | null>;
 
   /**
    * Returns column aggregate for the given column.

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -15,6 +15,9 @@ const getVersionInfo = () => {
 };
 
 export default defineConfig(({ mode }) => {
+  // Check for DOCKER_BUILD environment variable
+  const isDockerBuild = process.env.DOCKER_BUILD === 'true';
+
   return {
     mode: mode === 'int-test-build' ? 'production' : mode,
     define: {
@@ -25,7 +28,7 @@ export default defineConfig(({ mode }) => {
       react(),
       tsconfigPaths(),
       VitePWA({
-        disable: mode !== 'production',
+        disable: mode !== 'production' || isDockerBuild, // Disable PWA for Docker builds
         registerType: 'autoUpdate',
         workbox: {
           maximumFileSizeToCacheInBytes: 25000000,


### PR DESCRIPTION
## Description

Besides the subj it has:
* Removed service worker from docker build to stop polluting localhost's
* A couple of under the hood stabilizations in data-adapter
* A number of bugs in data-adapter fixed
* Increased the size of sort target in table headers
* Added `Refresh` overlay for when a long query to a data source is cancelled before any data has been loaded

What is lacking here:
* There is more refresh button in `data-view-pane` to allow force refreshing data after cancellation (similar to refresh overlay above)
* Support for cancelling scripts
* Unification of script execution state and data view state

## Related Issues

None, internal todo list from 0.2.0

## How to Test

Due to potentially breaking changes in data adapter state management I would go beyond our integration tests and try to do manual checks for everything related to data querying/scripts and how they aer displayed.

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
