### PR TITLE
[Bug]: Fix hotkey naming for creating a new script

### DIFF
--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -250,7 +250,7 @@ export const SpotlightMenu = () => {
       id: 'create-new-script',
       label: `New ${SCRIPT_DISPLAY_NAME}`,
       icon: <IconPlus size={20} className={ICON_CLASSES} />,
-      hotkey: [option, 'N'],
+      hotkey: [control, option, 'N'],
       handler: async () => {
         const newEmptyScript = createSQLScript();
         getOrCreateTabFromScript(newEmptyScript, true);

--- a/src/features/start-guide/start-guide.tsx
+++ b/src/features/start-guide/start-guide.tsx
@@ -34,7 +34,7 @@ export const StartGuide = () => {
       key: 'create-new-script',
       label: `New ${SCRIPT_DISPLAY_NAME}`,
       icon: <IconPlus size={20} className={ICON_CLASSES} />,
-      hotkey: ['Ctrl', 'Alt', 'N'],
+      hotkey: [mod.control, mod.option, 'N'],
       handler: () => {
         const newEmptyScript = createSQLScript();
         getOrCreateTabFromScript(newEmptyScript, true);


### PR DESCRIPTION
## Description

Fix hotkey naming for creating a new script

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
