### PR TITLE
Add batch close tabs action to spotlight

### DIFF
--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -26,6 +26,7 @@ import {
   IconFileSad,
   IconBooks,
   IconKeyboard,
+  IconX,
 } from '@tabler/icons-react';
 import { importSQLFiles } from '@utils/import-script-file';
 import { getFlatFileDataSourceName } from '@utils/navigation';

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -4,6 +4,7 @@ import {
   getOrCreateTabFromAttachedDBObject,
   getOrCreateTabFromFlatFileDataSource,
   getOrCreateTabFromScript,
+  deleteTab,
 } from '@controllers/tab';
 import { ImportScriptModalContent } from '@features/script-import';
 import { useAddLocalFilesOrFolders } from '@hooks/use-add-local-files-folders';
@@ -307,7 +308,39 @@ export const SpotlightMenu = () => {
     },
   ];
 
-  const quickActions: Action[] = [...scriptGroupActions, ...dataSourceGroupActions];
+  const tabActions: Action[] = [
+    {
+      id: 'close-all-tabs',
+      label: 'Close All Tabs',
+      icon: <IconX size={20} className={ICON_CLASSES} />,
+      hotkey: [option, 'W'],
+      handler: () => {
+        const { tabOrder } = useAppStore.getState();
+        if (tabOrder.length > 0) {
+          deleteTab(tabOrder);
+        }
+        Spotlight.close();
+      },
+    },
+    {
+      id: 'close-all-but-active-tab',
+      label: 'Close All But Active Tab',
+      icon: <IconX size={20} className={ICON_CLASSES} />,
+      hotkey: [option, control, 'W'],
+      handler: () => {
+        const { tabOrder, activeTabId } = useAppStore.getState();
+        if (tabOrder.length > 0 && activeTabId) {
+          const tabsToClose = tabOrder.filter(tabId => tabId !== activeTabId);
+          if (tabsToClose.length > 0) {
+            deleteTab(tabsToClose);
+          }
+        }
+        Spotlight.close();
+      },
+    },
+  ];
+
+  const quickActions: Action[] = [...scriptGroupActions, ...dataSourceGroupActions, ...tabActions];
 
   const searchModeActions: Action[] = [
     {


### PR DESCRIPTION
Signed-off-by: Alex Mazanov <alexandr.mazanov@gmail.com>## Description

Adds Close All Tabs and Close All But Active Tab actions to Spotlight

## Related Issues

Fixes #31

## How to Test

<!-- Provide step-by-step instructions on how to test this PR -->

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
