### PR TITLE
[FEATURE]: SQL Formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.23.1",
     "reactflow": "^11.11.4",
+    "sql-formatter": "^15.6.6",
     "tailwind-merge": "^2.5.2",
     "uuid": "^11.1.0",
     "vite-plugin-pwa": "^0.21.0",

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -1,3 +1,4 @@
+import { showError, showSuccess, showWarning } from '@components/app-notifications';
 import { NamedIcon } from '@components/named-icon';
 import { createSQLScript } from '@controllers/sql-script';
 import {
@@ -32,6 +33,7 @@ import {
 import { isLocalDatabase, isRemoteDatabase } from '@utils/data-source';
 import { importSQLFiles } from '@utils/import-script-file';
 import { getFlatFileDataSourceName } from '@utils/navigation';
+import { formatSQLSafe } from '@utils/sql-formatter';
 import { setDataTestId } from '@utils/test-id';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -280,6 +282,65 @@ export const SpotlightMenu = () => {
       handler: () => {
         openImportScriptModal();
         resetSpotlight();
+      },
+    },
+    {
+      id: 'format-sql',
+      label: 'Format SQL',
+      icon: <IconCode size={20} className={ICON_CLASSES} />,
+      hotkey: [control, 'Shift', 'I'],
+      handler: () => {
+        // Get the active tab and check if it's a script tab
+        const { activeTabId, tabs, sqlScripts } = useAppStore.getState();
+        if (!activeTabId) {
+          showError({
+            title: 'No active tab',
+            autoClose: 2000,
+          });
+          Spotlight.close();
+          return;
+        }
+
+        const activeTab = tabs.get(activeTabId);
+        if (!activeTab || activeTab.type !== 'script') {
+          showWarning({
+            title: 'Format SQL is only available in SQL script tabs',
+            autoClose: 3000,
+          });
+          Spotlight.close();
+          return;
+        }
+
+        const sqlScript = sqlScripts.get(activeTab.sqlScriptId);
+        if (!sqlScript) {
+          showError({
+            title: 'No SQL script found',
+            autoClose: 2000,
+          });
+          Spotlight.close();
+          return;
+        }
+
+        const formatResult = formatSQLSafe(sqlScript.content);
+        if (formatResult.success) {
+          // Update the script content
+          import('@controllers/sql-script').then(({ updateSQLScriptContent }) => {
+            updateSQLScriptContent(sqlScript, formatResult.result);
+            showSuccess({
+              title: 'SQL formatted successfully',
+              autoClose: 2000,
+              id: 'sql-format',
+            });
+          });
+        } else {
+          showError({
+            title: 'Failed to format SQL',
+            message: formatResult.error,
+            autoClose: 3000,
+            id: 'sql-format-error',
+          });
+        }
+        Spotlight.close();
       },
     },
   ];

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -1,4 +1,4 @@
-import { showError, showSuccess, showWarning } from '@components/app-notifications';
+import { showError, showWarning } from '@components/app-notifications';
 import { NamedIcon } from '@components/named-icon';
 import { createSQLScript } from '@controllers/sql-script';
 import {
@@ -33,7 +33,6 @@ import {
 import { isLocalDatabase, isRemoteDatabase } from '@utils/data-source';
 import { importSQLFiles } from '@utils/import-script-file';
 import { getFlatFileDataSourceName } from '@utils/navigation';
-import { formatSQLSafe } from '@utils/sql-formatter';
 import { setDataTestId } from '@utils/test-id';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -291,10 +290,11 @@ export const SpotlightMenu = () => {
       hotkey: [control, 'Shift', 'I'],
       handler: () => {
         // Get the active tab and check if it's a script tab
-        const { activeTabId, tabs, sqlScripts } = useAppStore.getState();
+        const { activeTabId, tabs, sqlScripts: scripts } = useAppStore.getState();
         if (!activeTabId) {
           showError({
             title: 'No active tab',
+            message: '',
             autoClose: 2000,
           });
           Spotlight.close();
@@ -305,41 +305,27 @@ export const SpotlightMenu = () => {
         if (!activeTab || activeTab.type !== 'script') {
           showWarning({
             title: 'Format SQL is only available in SQL script tabs',
+            message: '',
             autoClose: 3000,
           });
           Spotlight.close();
           return;
         }
 
-        const sqlScript = sqlScripts.get(activeTab.sqlScriptId);
+        const sqlScript = scripts.get(activeTab.sqlScriptId);
         if (!sqlScript) {
           showError({
             title: 'No SQL script found',
+            message: '',
             autoClose: 2000,
           });
           Spotlight.close();
           return;
         }
 
-        const formatResult = formatSQLSafe(sqlScript.content);
-        if (formatResult.success) {
-          // Update the script content
-          import('@controllers/sql-script').then(({ updateSQLScriptContent }) => {
-            updateSQLScriptContent(sqlScript, formatResult.result);
-            showSuccess({
-              title: 'SQL formatted successfully',
-              autoClose: 2000,
-              id: 'sql-format',
-            });
-          });
-        } else {
-          showError({
-            title: 'Failed to format SQL',
-            message: formatResult.error,
-            autoClose: 3000,
-            id: 'sql-format-error',
-          });
-        }
+        import('@controllers/sql-formatter').then(({ formatAndApplySQLScript }) => {
+          formatAndApplySQLScript(sqlScript);
+        });
         Spotlight.close();
       },
     },

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -287,7 +287,7 @@ export const SpotlightMenu = () => {
       id: 'format-sql',
       label: 'Format SQL',
       icon: <IconCode size={20} className={ICON_CLASSES} />,
-      hotkey: [control, 'Shift', 'I'],
+      hotkey: [control, 'Shift', 'F'],
       handler: () => {
         // Get the active tab and check if it's a script tab
         const { activeTabId, tabs, sqlScripts: scripts } = useAppStore.getState();

--- a/src/controllers/sql-formatter.ts
+++ b/src/controllers/sql-formatter.ts
@@ -1,0 +1,92 @@
+import { EditorView } from '@codemirror/view';
+import { showSuccess, showError } from '@components/app-notifications';
+import { SQLScript } from '@models/sql-script';
+import { formatSQLSafe } from '@utils/sql-formatter';
+
+import { updateSQLScriptContent } from './sql-script';
+
+/**
+ * Format and apply SQL to a script object
+ * @param sqlScript The SQL script to format
+ * @returns true if formatting was successful, false otherwise
+ */
+export async function formatAndApplySQLScript(sqlScript: SQLScript): Promise<boolean> {
+  const formatResult = formatSQLSafe(sqlScript.content);
+
+  if (formatResult.success) {
+    // Only update if the content has changed
+    if (sqlScript.content !== formatResult.result) {
+      await updateSQLScriptContent(sqlScript, formatResult.result);
+    }
+    showSuccess({
+      title: 'SQL formatted successfully',
+      message: '',
+      autoClose: 2000,
+      id: 'sql-format',
+    });
+    return true;
+  }
+  showError({
+    title: 'Failed to format SQL',
+    message: formatResult.error,
+    autoClose: 3000,
+    id: 'sql-format-error',
+  });
+  return false;
+}
+
+/**
+ * Format SQL in a CodeMirror editor view
+ * @param view The CodeMirror editor view
+ * @returns true if formatting was successful, false otherwise
+ */
+export function formatSQLInEditor(view: EditorView): boolean {
+  const selection = view.state.selection.main;
+  const hasSelection = !selection.empty;
+
+  let textToFormat: string;
+  let fromPos: number;
+  let toPos: number;
+
+  if (hasSelection) {
+    // Format only selected text
+    textToFormat = view.state.sliceDoc(selection.from, selection.to);
+    fromPos = selection.from;
+    toPos = selection.to;
+  } else {
+    // Format entire document
+    textToFormat = view.state.doc.toString();
+    fromPos = 0;
+    toPos = view.state.doc.length;
+  }
+
+  const formatResult = formatSQLSafe(textToFormat);
+
+  if (formatResult.success) {
+    // Replace the text with formatted SQL
+    view.dispatch({
+      changes: {
+        from: fromPos,
+        to: toPos,
+        insert: formatResult.result,
+      },
+      // Group this operation for undo/redo
+      userEvent: 'format',
+    });
+
+    showSuccess({
+      title: hasSelection ? 'Selection formatted' : 'SQL formatted successfully',
+      message: '',
+      autoClose: 2000,
+      id: 'sql-format',
+    });
+    return true;
+  }
+  showError({
+    title: 'Failed to format SQL',
+    message: formatResult.error,
+    autoClose: 3000,
+    id: 'sql-format-error',
+  });
+  return false;
+}

--- a/src/features/editor/sql-editor.tsx
+++ b/src/features/editor/sql-editor.tsx
@@ -14,12 +14,11 @@ import { defaultKeymap, insertTab, history } from '@codemirror/commands';
 import { sql, SQLNamespace, PostgreSQL } from '@codemirror/lang-sql';
 import { Prec } from '@codemirror/state';
 import { keymap, placeholder, ViewPlugin } from '@codemirror/view';
-import { showSuccess, showError } from '@components/app-notifications';
+import { showSuccess } from '@components/app-notifications';
 import { useAppStore } from '@store/app-store';
 import CodeMirror, { EditorView, Extension, ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { SqlStatementHighlightPlugin } from '@utils/editor/highlight-plugin';
 import { KEY_BINDING } from '@utils/hotkey/key-matcher';
-import { formatSQLSafe } from '@utils/sql-formatter';
 import { forwardRef, KeyboardEventHandler, useMemo, useRef } from 'react';
 
 import { aiAssistantStateField } from './ai-assistant/state-field';
@@ -119,6 +118,7 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
                   onFontSizeChanged(newFontSize);
                   showSuccess({
                     title: `Font size: ${Math.floor(newFontSize * 100)}%`,
+                    message: '',
                     autoClose: 1000,
                     id: 'font-size',
                   });
@@ -136,6 +136,7 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
                   onFontSizeChanged(newFontSize);
                   showSuccess({
                     title: `Font size: ${Math.floor(newFontSize * 100)}%`,
+                    message: '',
                     autoClose: 1000,
                     id: 'font-size',
                   });
@@ -147,31 +148,9 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
               key: KEY_BINDING.format.toCodeMirrorKey(),
               preventDefault: true,
               run: (view) => {
-                const currentCode = view.state.doc.toString();
-                const formatResult = formatSQLSafe(currentCode);
-
-                if (formatResult.success) {
-                  // Replace the entire document with formatted SQL
-                  view.dispatch({
-                    changes: {
-                      from: 0,
-                      to: view.state.doc.length,
-                      insert: formatResult.result,
-                    },
-                  });
-                  showSuccess({
-                    title: 'SQL formatted successfully',
-                    autoClose: 2000,
-                    id: 'sql-format',
-                  });
-                } else {
-                  showError({
-                    title: 'Failed to format SQL',
-                    message: formatResult.error,
-                    autoClose: 3000,
-                    id: 'sql-format-error',
-                  });
-                }
+                import('@controllers/sql-formatter').then(({ formatSQLInEditor }) => {
+                  formatSQLInEditor(view);
+                });
                 return true;
               },
             },

--- a/src/features/editor/sql-editor.tsx
+++ b/src/features/editor/sql-editor.tsx
@@ -14,11 +14,12 @@ import { defaultKeymap, insertTab, history } from '@codemirror/commands';
 import { sql, SQLNamespace, PostgreSQL } from '@codemirror/lang-sql';
 import { Prec } from '@codemirror/state';
 import { keymap, placeholder, ViewPlugin } from '@codemirror/view';
-import { showNotification } from '@mantine/notifications';
+import { showSuccess, showError } from '@components/app-notifications';
 import { useAppStore } from '@store/app-store';
 import CodeMirror, { EditorView, Extension, ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { SqlStatementHighlightPlugin } from '@utils/editor/highlight-plugin';
 import { KEY_BINDING } from '@utils/hotkey/key-matcher';
+import { formatSQLSafe } from '@utils/sql-formatter';
 import { forwardRef, KeyboardEventHandler, useMemo, useRef } from 'react';
 
 import { aiAssistantStateField } from './ai-assistant/state-field';
@@ -116,8 +117,8 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
                 if (onFontSizeChanged) {
                   const newFontSize = Math.min(2, (fontSize ?? 1) + 0.2);
                   onFontSizeChanged(newFontSize);
-                  showNotification({
-                    message: `Change code editor font size to ${Math.floor(newFontSize * 100)}%`,
+                  showSuccess({
+                    title: `Font size: ${Math.floor(newFontSize * 100)}%`,
                     autoClose: 1000,
                     id: 'font-size',
                   });
@@ -133,10 +134,42 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
                 if (onFontSizeChanged) {
                   const newFontSize = Math.max(0.4, (fontSize ?? 1) - 0.2);
                   onFontSizeChanged(newFontSize);
-                  showNotification({
-                    message: `Change code editor font size to ${Math.floor(newFontSize * 100)}%`,
+                  showSuccess({
+                    title: `Font size: ${Math.floor(newFontSize * 100)}%`,
                     autoClose: 1000,
                     id: 'font-size',
+                  });
+                }
+                return true;
+              },
+            },
+            {
+              key: KEY_BINDING.format.toCodeMirrorKey(),
+              preventDefault: true,
+              run: (view) => {
+                const currentCode = view.state.doc.toString();
+                const formatResult = formatSQLSafe(currentCode);
+
+                if (formatResult.success) {
+                  // Replace the entire document with formatted SQL
+                  view.dispatch({
+                    changes: {
+                      from: 0,
+                      to: view.state.doc.length,
+                      insert: formatResult.result,
+                    },
+                  });
+                  showSuccess({
+                    title: 'SQL formatted successfully',
+                    autoClose: 2000,
+                    id: 'sql-format',
+                  });
+                } else {
+                  showError({
+                    title: 'Failed to format SQL',
+                    message: formatResult.error,
+                    autoClose: 3000,
+                    id: 'sql-format-error',
                   });
                 }
                 return true;

--- a/src/features/editor/sql-editor.tsx
+++ b/src/features/editor/sql-editor.tsx
@@ -15,6 +15,7 @@ import { sql, SQLNamespace, PostgreSQL } from '@codemirror/lang-sql';
 import { Prec } from '@codemirror/state';
 import { keymap, placeholder, ViewPlugin } from '@codemirror/view';
 import { showSuccess } from '@components/app-notifications';
+import { useEditorPreferences } from '@hooks/use-editor-preferences';
 import { useAppStore } from '@store/app-store';
 import CodeMirror, { EditorView, Extension, ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { SqlStatementHighlightPlugin } from '@utils/editor/highlight-plugin';
@@ -46,8 +47,6 @@ interface SqlEditorProps {
   onChange?: (value: string) => void;
   schema?: SQLNamespace;
   onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
-  fontSize?: number;
-  onFontSizeChanged?: (fontSize: number) => void;
   onCursorChange?: (pos: number, lineNumber: number, columnNumber: number) => void;
   onBlur: () => void;
   functionTooltips: FunctionTooltip;
@@ -63,8 +62,6 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
       onKeyDown,
       onCursorChange,
       readOnly,
-      fontSize,
-      onFontSizeChanged,
       onBlur,
       functionTooltips,
     }: SqlEditorProps,
@@ -74,6 +71,7 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
     const connectionPool = useDuckDBConnectionPool();
     const editorRef = useRef<ReactCodeMirrorRef>(null);
     const sqlScripts = useAppStore((state) => state.sqlScripts);
+    const { preferences, updatePreference } = useEditorPreferences();
 
     const tableNameHighlightPlugin = useMemo(() => {
       if (schema) {
@@ -113,16 +111,14 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
               mac: 'Cmd-=',
               preventDefault: true,
               run: () => {
-                if (onFontSizeChanged) {
-                  const newFontSize = Math.min(2, (fontSize ?? 1) + 0.2);
-                  onFontSizeChanged(newFontSize);
-                  showSuccess({
-                    title: `Font size: ${Math.floor(newFontSize * 100)}%`,
-                    message: '',
-                    autoClose: 1000,
-                    id: 'font-size',
-                  });
-                }
+                const newFontSize = Math.min(2, preferences.fontSize + 0.1);
+                updatePreference('fontSize', newFontSize);
+                showSuccess({
+                  title: `Font size: ${Math.floor(newFontSize * 100)}%`,
+                  message: '',
+                  autoClose: 1000,
+                  id: 'font-size',
+                });
                 return true;
               },
             },
@@ -131,16 +127,14 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
               mac: 'Cmd--',
               preventDefault: true,
               run: () => {
-                if (onFontSizeChanged) {
-                  const newFontSize = Math.max(0.4, (fontSize ?? 1) - 0.2);
-                  onFontSizeChanged(newFontSize);
-                  showSuccess({
-                    title: `Font size: ${Math.floor(newFontSize * 100)}%`,
-                    message: '',
-                    autoClose: 1000,
-                    id: 'font-size',
-                  });
-                }
+                const newFontSize = Math.max(0.4, preferences.fontSize - 0.1);
+                updatePreference('fontSize', newFontSize);
+                showSuccess({
+                  title: `Font size: ${Math.floor(newFontSize * 100)}%`,
+                  message: '',
+                  autoClose: 1000,
+                  id: 'font-size',
+                });
                 return true;
               },
             },
@@ -169,7 +163,7 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
             }),
           ]),
         ),
-      [fontSize, onFontSizeChanged],
+      [preferences.fontSize, updatePreference],
     );
 
     const extensions = useMemo(() => {
@@ -282,7 +276,7 @@ export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
         width="100%"
         onChange={onChange}
         style={{
-          fontSize: fontSize ? `${fontSize}rem` : '0.875rem',
+          fontSize: `${preferences.fontSize}rem`,
           height: '100%',
           width: '100%',
           flex: 1,

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -47,7 +47,6 @@ export const ScriptEditor = ({
    * State
    */
   const editorRef = useRef<ReactCodeMirrorRef>(null);
-  const [fontSize, setFontSize] = useState(0.875);
   const [dirty, setDirty] = useState(false);
   const [lastExecutedContent, setLastExecutedContent] = useState('');
 
@@ -195,14 +194,6 @@ export const ScriptEditor = ({
     }
   };
 
-  const handleFormatClick = () => {
-    if (editorRef.current?.view) {
-      import('@controllers/sql-formatter').then(({ formatSQLInEditor }) => {
-        formatSQLInEditor(editorRef.current!.view!);
-      });
-    }
-  };
-
   return (
     <div
       className="h-full"
@@ -224,8 +215,6 @@ export const ScriptEditor = ({
           value={sqlScript?.content || ''}
           onChange={onSqlEditorChange}
           schema={schema}
-          fontSize={fontSize}
-          onFontSizeChanged={setFontSize}
           functionTooltips={functionTooltips}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
             if (KEY_BINDING.run.match(e)) {

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -1,4 +1,4 @@
-import { showAlert } from '@components/app-notifications';
+import { showAlert, showSuccess, showError } from '@components/app-notifications';
 import { createSQLScript, updateSQLScriptContent } from '@controllers/sql-script';
 import { getOrCreateTabFromScript } from '@controllers/tab';
 import { SqlEditor } from '@features/editor';
@@ -14,6 +14,7 @@ import { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { convertFunctionsToTooltips } from '@utils/convert-functions-to-tooltip';
 import { splitSqlQuery } from '@utils/editor/statement-parser';
 import { KEY_BINDING } from '@utils/hotkey/key-matcher';
+import { formatSQLSafe } from '@utils/sql-formatter';
 import { setDataTestId } from '@utils/test-id';
 import { useEffect, useRef, useState, useMemo } from 'react';
 
@@ -191,6 +192,37 @@ export const ScriptEditor = ({
         const { tabExecutionErrors } = useAppStore.getState();
         const errorContext = tabExecutionErrors.get(tabId);
         showAIAssistant(view, errorContext);
+      }
+    }
+  };
+
+  const handleFormatClick = () => {
+    if (editorRef.current?.view) {
+      const { view } = editorRef.current;
+      const currentCode = view.state.doc.toString();
+      const formatResult = formatSQLSafe(currentCode);
+
+      if (formatResult.success) {
+        // Replace the entire document with formatted SQL
+        view.dispatch({
+          changes: {
+            from: 0,
+            to: view.state.doc.length,
+            insert: formatResult.result,
+          },
+        });
+        showSuccess({
+          title: 'SQL formatted successfully',
+          autoClose: 2000,
+          id: 'sql-format',
+        });
+      } else {
+        showError({
+          title: 'Failed to format SQL',
+          message: formatResult.error,
+          autoClose: 3000,
+          id: 'sql-format-error',
+        });
       }
     }
   };

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -1,4 +1,4 @@
-import { showAlert, showSuccess, showError } from '@components/app-notifications';
+import { showAlert } from '@components/app-notifications';
 import { createSQLScript, updateSQLScriptContent } from '@controllers/sql-script';
 import { getOrCreateTabFromScript } from '@controllers/tab';
 import { SqlEditor } from '@features/editor';
@@ -14,7 +14,6 @@ import { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { convertFunctionsToTooltips } from '@utils/convert-functions-to-tooltip';
 import { splitSqlQuery } from '@utils/editor/statement-parser';
 import { KEY_BINDING } from '@utils/hotkey/key-matcher';
-import { formatSQLSafe } from '@utils/sql-formatter';
 import { setDataTestId } from '@utils/test-id';
 import { useEffect, useRef, useState, useMemo } from 'react';
 
@@ -198,32 +197,9 @@ export const ScriptEditor = ({
 
   const handleFormatClick = () => {
     if (editorRef.current?.view) {
-      const { view } = editorRef.current;
-      const currentCode = view.state.doc.toString();
-      const formatResult = formatSQLSafe(currentCode);
-
-      if (formatResult.success) {
-        // Replace the entire document with formatted SQL
-        view.dispatch({
-          changes: {
-            from: 0,
-            to: view.state.doc.length,
-            insert: formatResult.result,
-          },
-        });
-        showSuccess({
-          title: 'SQL formatted successfully',
-          autoClose: 2000,
-          id: 'sql-format',
-        });
-      } else {
-        showError({
-          title: 'Failed to format SQL',
-          message: formatResult.error,
-          autoClose: 3000,
-          id: 'sql-format-error',
-        });
-      }
+      import('@controllers/sql-formatter').then(({ formatSQLInEditor }) => {
+        formatSQLInEditor(editorRef.current!.view!);
+      });
     }
   };
 

--- a/src/features/tab-view/views/script-tab-view.tsx
+++ b/src/features/tab-view/views/script-tab-view.tsx
@@ -11,6 +11,7 @@ import {
 import { useInitializedDuckDBConnectionPool } from '@features/duckdb-context/duckdb-context';
 import { AsyncDuckDBPooledPreparedStatement } from '@features/duckdb-context/duckdb-pooled-prepared-stmt';
 import { ScriptEditor } from '@features/script-editor';
+import { useEditorPreferences } from '@hooks/use-editor-preferences';
 import { RemoteDB } from '@models/data-source';
 import { ScriptExecutionState } from '@models/sql-script';
 import { ScriptTab, TabId } from '@models/tab';
@@ -24,6 +25,7 @@ import {
   SQLStatement,
   SQLStatementType,
 } from '@utils/editor/sql';
+import { formatSQLSafe } from '@utils/sql-formatter';
 import { Allotment } from 'allotment';
 import { memo, useCallback, useState } from 'react';
 
@@ -60,12 +62,28 @@ export const ScriptTabView = memo(({ tabId, active }: ScriptTabViewProps) => {
 
   const pool = useInitializedDuckDBConnectionPool();
   const protectedViews = useProtectedViews();
+  const { preferences } = useEditorPreferences();
 
   const runScriptQuery = useCallback(
     async (query: string) => {
       setScriptExecutionState('running');
+
+      // Format query if preference is enabled
+      let queryToExecute = query;
+      if (preferences.formatOnRun) {
+        const formatResult = formatSQLSafe(query);
+        if (formatResult.success) {
+          queryToExecute = formatResult.result;
+          // Update the editor with formatted SQL
+          const sqlScript = useAppStore.getState().sqlScripts.get(tab.sqlScriptId);
+          if (sqlScript && sqlScript.content !== queryToExecute) {
+            const { updateSQLScriptContent } = await import('@controllers/sql-script');
+            updateSQLScriptContent(sqlScript, queryToExecute);
+          }
+        }
+      }
       // Parse query into statements
-      const statements = splitSQLByStats(query);
+      const statements = splitSQLByStats(queryToExecute);
 
       // Classify statements
       const classifiedStatements = classifySQLStatements(statements);
@@ -365,7 +383,7 @@ export const ScriptTabView = memo(({ tabId, active }: ScriptTabViewProps) => {
       // update the state and trigger re-render.
       updateScriptTabLastExecutedQuery({ tabId, lastExecutedQuery, force: true });
     },
-    [pool, protectedViews, tabId, incrementScriptVersion],
+    [pool, protectedViews, tabId, incrementScriptVersion, preferences, tab.sqlScriptId],
   );
 
   const setPanelSize = ([editor, table]: number[]) => {

--- a/src/features/tab-view/views/script-tab-view.tsx
+++ b/src/features/tab-view/views/script-tab-view.tsx
@@ -1,4 +1,4 @@
-import { showError, showErrorWithAction } from '@components/app-notifications';
+import { showError, showErrorWithAction, showSuccess } from '@components/app-notifications';
 import { persistPutDataSources, persistDeleteDataSource } from '@controllers/data-source/persist';
 import { getDatabaseModel } from '@controllers/db/duckdb-meta';
 import { syncFiles } from '@controllers/file-system';
@@ -79,6 +79,12 @@ export const ScriptTabView = memo(({ tabId, active }: ScriptTabViewProps) => {
           if (sqlScript && sqlScript.content !== queryToExecute) {
             const { updateSQLScriptContent } = await import('@controllers/sql-script');
             updateSQLScriptContent(sqlScript, queryToExecute);
+            showSuccess({
+              title: 'Query auto-formatted',
+              message: '',
+              autoClose: 1500,
+              id: 'sql-auto-format',
+            });
           }
         }
       }

--- a/src/hooks/use-editor-preferences.ts
+++ b/src/hooks/use-editor-preferences.ts
@@ -1,0 +1,38 @@
+import {
+  EditorPreferences,
+  getEditorPreferences,
+  updateEditorPreference,
+} from '@store/editor-preferences';
+import { useState, useCallback, useEffect } from 'react';
+
+/**
+ * Hook to manage editor preferences with localStorage persistence
+ */
+export function useEditorPreferences() {
+  const [preferences, setPreferences] = useState<EditorPreferences>(getEditorPreferences);
+
+  // Listen for storage changes from other tabs
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'pondpilot-editor-preferences') {
+        setPreferences(getEditorPreferences());
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, []);
+
+  const updatePreference = useCallback(
+    <K extends keyof EditorPreferences>(key: K, value: EditorPreferences[K]) => {
+      updateEditorPreference(key, value);
+      setPreferences((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  return {
+    preferences,
+    updatePreference,
+  };
+}

--- a/src/pages/settings-page/components/editor-settings/editor-settings.tsx
+++ b/src/pages/settings-page/components/editor-settings/editor-settings.tsx
@@ -1,5 +1,5 @@
 import { useEditorPreferences } from '@hooks/use-editor-preferences';
-import { Stack, Box, Title, Text, Switch, Group } from '@mantine/core';
+import { Stack, Box, Title, Text, Switch, Group, Slider } from '@mantine/core';
 
 export const EditorSettings = () => {
   const { preferences, updatePreference } = useEditorPreferences();
@@ -31,6 +31,35 @@ export const EditorSettings = () => {
                 size="md"
               />
             </Group>
+          </Stack>
+        </Box>
+        <Box>
+          <Title c="text-primary" order={3}>
+            Appearance
+          </Title>
+          <Stack>
+            <Text c="text-secondary">Customize the appearance of the code editor.</Text>
+            <Box className="max-w-md">
+              <Text c="text-primary" size="sm" fw={500} mb="xs">
+                Font size
+              </Text>
+              <Text c="text-secondary" size="xs" mb="sm">
+                Adjust the font size of the code editor ({Math.floor(preferences.fontSize * 100)}%)
+              </Text>
+              <Slider
+                value={preferences.fontSize}
+                onChange={(value) => updatePreference('fontSize', value)}
+                min={0.4}
+                max={2}
+                step={0.1}
+                marks={[
+                  { value: 0.5, label: '50%' },
+                  { value: 1, label: '100%' },
+                  { value: 1.5, label: '150%' },
+                  { value: 2, label: '200%' },
+                ]}
+              />
+            </Box>
           </Stack>
         </Box>
       </Stack>

--- a/src/pages/settings-page/components/editor-settings/editor-settings.tsx
+++ b/src/pages/settings-page/components/editor-settings/editor-settings.tsx
@@ -1,0 +1,39 @@
+import { useEditorPreferences } from '@hooks/use-editor-preferences';
+import { Stack, Box, Title, Text, Switch, Group } from '@mantine/core';
+
+export const EditorSettings = () => {
+  const { preferences, updatePreference } = useEditorPreferences();
+
+  return (
+    <Stack className="gap-8">
+      <Title c="text-primary" order={2}>
+        Editor
+      </Title>
+      <Stack>
+        <Box>
+          <Title c="text-primary" order={3}>
+            SQL Formatting
+          </Title>
+          <Stack>
+            <Text c="text-secondary">Configure how SQL queries are formatted in the editor.</Text>
+            <Group justify="space-between" className="max-w-md">
+              <Box>
+                <Text c="text-primary" size="sm" fw={500}>
+                  Format on run
+                </Text>
+                <Text c="text-secondary" size="xs">
+                  Automatically format SQL queries before execution
+                </Text>
+              </Box>
+              <Switch
+                checked={preferences.formatOnRun}
+                onChange={(event) => updatePreference('formatOnRun', event.currentTarget.checked)}
+                size="md"
+              />
+            </Group>
+          </Stack>
+        </Box>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/pages/settings-page/components/editor-settings/index.ts
+++ b/src/pages/settings-page/components/editor-settings/index.ts
@@ -1,0 +1,1 @@
+export { EditorSettings } from './editor-settings';

--- a/src/pages/settings-page/settings-page.tsx
+++ b/src/pages/settings-page/settings-page.tsx
@@ -19,6 +19,7 @@ import { setDataTestId } from '@utils/test-id';
 import { useNavigate } from 'react-router-dom';
 
 import { AISettings } from './components/ai-settings';
+import { EditorSettings } from './components/editor-settings';
 import { ThemeSwitcher } from './components/theme-switcher';
 
 export const SettingsPage = () => {
@@ -88,6 +89,8 @@ export const SettingsPage = () => {
 
           <Divider />
           <AISettings />
+          <Divider />
+          <EditorSettings />
           <Divider />
           <Stack className="gap-8">
             <Title c="text-primary" order={2}>

--- a/src/store/editor-preferences.ts
+++ b/src/store/editor-preferences.ts
@@ -1,0 +1,66 @@
+/**
+ * Editor preferences stored in localStorage
+ */
+
+export interface EditorPreferences {
+  formatOnRun: boolean;
+  fontSize: number;
+}
+
+const EDITOR_PREFERENCES_KEY = 'pondpilot-editor-preferences';
+
+const defaultPreferences: EditorPreferences = {
+  formatOnRun: false,
+  fontSize: 0.875,
+};
+
+/**
+ * Get editor preferences from localStorage
+ */
+export function getEditorPreferences(): EditorPreferences {
+  try {
+    const stored = localStorage.getItem(EDITOR_PREFERENCES_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Merge with defaults to handle missing fields
+      return { ...defaultPreferences, ...parsed };
+    }
+  } catch (error) {
+    console.error('Failed to load editor preferences:', error);
+  }
+  return defaultPreferences;
+}
+
+/**
+ * Save editor preferences to localStorage
+ */
+export function saveEditorPreferences(preferences: Partial<EditorPreferences>): void {
+  try {
+    const current = getEditorPreferences();
+    const updated = { ...current, ...preferences };
+    localStorage.setItem(EDITOR_PREFERENCES_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.error('Failed to save editor preferences:', error);
+  }
+}
+
+/**
+ * Update a single preference
+ */
+export function updateEditorPreference<K extends keyof EditorPreferences>(
+  key: K,
+  value: EditorPreferences[K],
+): void {
+  saveEditorPreferences({ [key]: value });
+}
+
+/**
+ * Reset editor preferences to defaults
+ */
+export function resetEditorPreferences(): void {
+  try {
+    localStorage.removeItem(EDITOR_PREFERENCES_KEY);
+  } catch (error) {
+    console.error('Failed to reset editor preferences:', error);
+  }
+}

--- a/src/utils/hotkey/key-matcher.ts
+++ b/src/utils/hotkey/key-matcher.ts
@@ -93,7 +93,7 @@ export const KEY_BINDING = {
   save: new KeyMatcher({ ctrl: true, key: 's' }),
   copy: new KeyMatcher({ ctrl: true, key: 'c' }),
   paste: new KeyMatcher({ ctrl: true, key: 'v' }),
-  format: new KeyMatcher({ ctrl: true, shift: true, key: 'i' }),
+  format: new KeyMatcher({ ctrl: true, shift: true, key: 'f' }),
   kmenu: new KeyMatcher({ ctrl: true, key: 'k' }),
   runSelection: new KeyMatcher({ ctrl: true, shift: true, key: 'Enter' }),
   openNewScript: new KeyMatcher({ ctrl: true, alt: true, key: 'n' }),

--- a/src/utils/sql-formatter.ts
+++ b/src/utils/sql-formatter.ts
@@ -16,8 +16,7 @@ export function formatSQLSafe(sql: string): { success: boolean; result: string; 
 
   try {
     const formatted = format(sql, {
-      language: 'sql',
-      dialect: 'duckdb',
+      language: 'duckdb',
       keywordCase: 'upper',
     });
     return {

--- a/src/utils/sql-formatter.ts
+++ b/src/utils/sql-formatter.ts
@@ -1,0 +1,34 @@
+import { format } from 'sql-formatter';
+
+/**
+ * Format SQL and return result with success status
+ * @param sql The SQL query to format
+ * @returns Object with formatted SQL and success status
+ */
+export function formatSQLSafe(sql: string): { success: boolean; result: string; error?: string } {
+  if (!sql || !sql.trim()) {
+    return {
+      success: false,
+      result: sql,
+      error: 'Empty SQL query',
+    };
+  }
+
+  try {
+    const formatted = format(sql, {
+      language: 'sql',
+      dialect: 'duckdb',
+      keywordCase: 'upper',
+    });
+    return {
+      success: true,
+      result: formatted,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      result: sql,
+      error: error instanceof Error ? error.message : 'Failed to format SQL query',
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,7 +5243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0":
+"commander@npm:^2.19.0, commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -5748,6 +5748,13 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
+  languageName: node
+  linkType: hard
+
+"discontinuous-range@npm:1.0.0":
+  version: 1.0.0
+  resolution: "discontinuous-range@npm:1.0.0"
+  checksum: 10c0/487b105f83c1cc528e25e65d3c4b73958ec79769b7bd0e264414702a23a7e2b282c72982b4bef4af29fcab53f47816c3f0a5c40d85a99a490f4bc35b83dc00f8
   languageName: node
   linkType: hard
 
@@ -9605,6 +9612,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moo@npm:^0.5.0":
+  version: 0.5.2
+  resolution: "moo@npm:0.5.2"
+  checksum: 10c0/a9d9ad8198a51fe35d297f6e9fdd718298ca0b39a412e868a0ebd92286379ab4533cfc1f1f34516177f5129988ab25fe598f78e77c84e3bfe0d4a877b56525a8
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -9645,6 +9659,23 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
+"nearley@npm:^2.20.1":
+  version: 2.20.1
+  resolution: "nearley@npm:2.20.1"
+  dependencies:
+    commander: "npm:^2.19.0"
+    moo: "npm:^0.5.0"
+    railroad-diagrams: "npm:^1.0.0"
+    randexp: "npm:0.4.6"
+  bin:
+    nearley-railroad: bin/nearley-railroad.js
+    nearley-test: bin/nearley-test.js
+    nearley-unparse: bin/nearley-unparse.js
+    nearleyc: bin/nearleyc.js
+  checksum: 10c0/d25e1fd40b19c53a0ada6a688670f4a39063fd9553ab62885e81a82927d51572ce47193b946afa3d85efa608ba2c68f433c421f69b854bfb7f599eacb5fae37e
   languageName: node
   linkType: hard
 
@@ -10199,6 +10230,7 @@ __metadata:
     react-markdown: "npm:^10.1.0"
     react-router-dom: "npm:^6.23.1"
     reactflow: "npm:^11.11.4"
+    sql-formatter: "npm:^15.6.6"
     stylelint: "npm:^16.6.1"
     stylelint-config-standard-scss: "npm:^13.1.0"
     tailwind-merge: "npm:^2.5.2"
@@ -10541,6 +10573,23 @@ __metadata:
   version: 4.0.3
   resolution: "raf-schd@npm:4.0.3"
   checksum: 10c0/ecabf0957c05fad059779bddcd992f1a9d3a35dfea439a6f0935c382fcf4f7f7fa60489e467b4c2db357a3665167d2a379782586b59712bb36c766e02824709b
+  languageName: node
+  linkType: hard
+
+"railroad-diagrams@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "railroad-diagrams@npm:1.0.0"
+  checksum: 10c0/81bf8f86870a69fb9ed243102db9ad6416d09c4cb83964490d44717690e07dd982f671503236a1f8af28f4cb79d5d7a87613930f10ac08defa845ceb6764e364
+  languageName: node
+  linkType: hard
+
+"randexp@npm:0.4.6":
+  version: 0.4.6
+  resolution: "randexp@npm:0.4.6"
+  dependencies:
+    discontinuous-range: "npm:1.0.0"
+    ret: "npm:~0.1.10"
+  checksum: 10c0/14ee14b6d7f5ce69609b51cc914fb7a7c82ad337820a141c5f762c5ad1fe868f5191ea6e82359aee019b625ee1359486628fa833909d12c3b5dd9571908c3345
   languageName: node
   linkType: hard
 
@@ -11049,6 +11098,13 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
+  languageName: node
+  linkType: hard
+
+"ret@npm:~0.1.10":
+  version: 0.1.15
+  resolution: "ret@npm:0.1.15"
+  checksum: 10c0/01f77cad0f7ea4f955852c03d66982609893edc1240c0c964b4c9251d0f9fb6705150634060d169939b096d3b77f4c84d6b6098a5b5d340160898c8581f1f63f
   languageName: node
   linkType: hard
 
@@ -11672,6 +11728,18 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
+  languageName: node
+  linkType: hard
+
+"sql-formatter@npm:^15.6.6":
+  version: 15.6.6
+  resolution: "sql-formatter@npm:15.6.6"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    nearley: "npm:^2.20.1"
+  bin:
+    sql-formatter: bin/sql-formatter-cli.cjs
+  checksum: 10c0/32fc38574d9aa41adeb74f94d36f21259682617ed430311c39f44849c8049f8d1ec4b25a30c6ab51d933aaeb2f12ab22470b6536a6a0feb77b8d5414dfcb18e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Signed-off-by: Alex Mazanov <alexandr.mazanov@gmail.com>## Description


🎨 SQL Formatting

- Manual formatting via keyboard shortcut (Ctrl/Cmd+Shift+F) or
command palette
- Auto-format on run option that formats SQL before execution
- Support for formatting entire document or selected text
- Uses sql-formatter library with DuckDB dialect support
- Proper error handling with user-friendly notifications

⚙️ Editor Preferences

- New preferences system with localStorage persistence
- Configurable font size (40%-200%) with slider control in settings
- Format-on-run toggle in editor settings

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" -->

## How to Test

<!-- Provide step-by-step instructions on how to test this PR -->

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
