### PR TITLE
[Infra]: Add cache control headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,82 @@
+# Cache Control Headers for Different File Types
+
+# HTML files - no caching to ensure fresh content
+/*.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Service Worker - no caching for immediate updates
+/sw.js
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Manifest - no caching to ensure updates are reflected
+/manifest.json
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# JavaScript and CSS files - aggressive caching (1 year)
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+# WASM files - aggressive caching (1 year)
+/*.wasm
+  Cache-Control: public, max-age=31536000, immutable
+
+# Static assets - medium-term caching (30 days)
+/*.png
+  Cache-Control: public, max-age=2592000
+
+/*.svg
+  Cache-Control: public, max-age=2592000
+
+/*.ico
+  Cache-Control: public, max-age=2592000
+
+/*.jpg
+  Cache-Control: public, max-age=2592000
+
+/*.jpeg
+  Cache-Control: public, max-age=2592000
+
+/*.webp
+  Cache-Control: public, max-age=2592000
+
+# Fonts - aggressive caching (1 year)
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ttf
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.otf
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.eot
+  Cache-Control: public, max-age=31536000, immutable
+
+# JSON files - no caching to ensure fresh data
+/*.json
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Favicon - short-term caching (24 hours)
+/favicon.ico
+  Cache-Control: public, max-age=86400
+
+# Security Headers for all files
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-XSS-Protection: 1; mode=block

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -30,6 +30,9 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         disable: mode !== 'production' || isDockerBuild, // Disable PWA for Docker builds
         registerType: 'autoUpdate',
+        clientsClaim: true,
+        skipWaiting: true,
+        cleanupOutdatedCaches: true,
         workbox: {
           maximumFileSizeToCacheInBytes: 25000000,
           // Cache duckdb CDN resources


### PR DESCRIPTION
## Description

  Implements aggressive caching strategy and PWA optimizations for improved offline
  performance and faster loading times.

  Key changes:
  - Added _headers file with Cloudflare-compatible cache control rules
  - Configured aggressive caching for static assets (JS/CSS/WASM: 1 year, images: 30
  days)
  - Added security headers (X-Frame-Options, X-Content-Type-Options, etc.)
  - Updated PWA settings for instant service worker updates (skipWaiting, clientsClaim,
   cleanupOutdatedCaches)
  - Ensured fresh content delivery for HTML, service worker, and manifest files

## Related Issues

 Fixes #129

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

  The app will be deployed to a preview URL automatically every time you push a commit to this PR.

  You can find the preview link in the "Deployments" section at the bottom of this PR:
  - Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
  - Alternatively, look for "github-actions bot deployed to preview" in the timeline.
  - Click "View deployment" to open the preview URL.
</details>
