### PR TITLE
fix just error via adding shebang for multi-line recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ default:
     just --list
 
 docker-build base_path='/':
+  #!/usr/bin/env sh
   # Validate and normalize base_path
   if [[ "{{base_path}}" != /* ]]; then
     echo "Base path must start with a slash. Prepending automatically." >&2


### PR DESCRIPTION
## Description

fix just error via adding shebang for multi-line recipe: https://just.systems/man/en/multi-line-constructs.html

## Related Issues

Fixes #233 

## How to Test

`just`

## Checklist

- [x] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [x] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

The app will be deployed to a preview URL automatically every time you push a commit to this PR.

You can find the preview link in the "Deployments" section at the bottom of this PR:

- Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
- Alternatively, look for "github-actions bot deployed to preview" in the timeline.
- Click "View deployment" to open the preview URL.
</details>
