### PR TITLE
Fix dbname parsing in proxied ATTACH statement

### DIFF
--- a/src/utils/attach-parser.ts
+++ b/src/utils/attach-parser.ts
@@ -62,9 +62,14 @@ export function parseAttachStatement(statement: string): ParsedAttachStatement |
   // Group 3: Database name (required)
   const [, rawUrl, , dbName] = match;
 
+  // DuckDB doesn't allow semicolons in unquoted identifiers, but scripts often
+  // terminate statements with `;` without whitespace ("AS mydb;"). Strip the
+  // trailing semicolon so the parsed database name matches DuckDB's actual alias.
+  const normalizedDbName = dbName.replace(/;$/, '');
+
   return {
     rawUrl,
-    dbName,
+    dbName: normalizedDbName,
     statement,
   };
 }

--- a/tests/unit/utils/attach-parser.test.ts
+++ b/tests/unit/utils/attach-parser.test.ts
@@ -77,6 +77,15 @@ describe('attach-parser', () => {
       });
     });
 
+    it('should ignore trailing semicolons after the database name', () => {
+      const result = parseAttachStatement("ATTACH 'https://example.com/db.duckdb' AS mydb;");
+      expect(result).toEqual({
+        rawUrl: 'https://example.com/db.duckdb',
+        dbName: 'mydb',
+        statement: "ATTACH 'https://example.com/db.duckdb' AS mydb;",
+      });
+    });
+
     it('should parse S3 URLs', () => {
       const result = parseAttachStatement("ATTACH 's3://bucket/data.duckdb' AS s3db");
       expect(result).toEqual({


### PR DESCRIPTION
## Description

`ATTACH` 's3://pondpilot/chinook.duckdb' AS chinook;` would create a database named 'chinook;'. This PR fixes this issues.

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" -->

## How to Test

<!-- Provide step-by-step instructions on how to test this PR -->

## Checklist

- [ ] I have added at least one test for the new feature or fixed bug, or this PR does not include any app code changes.
- [ ] I have tested the new version using the auto-generated preview URL.

<details>
  <summary>How to Find the Preview URL</summary>

The app will be deployed to a preview URL automatically every time you push a commit to this PR.

You can find the preview link in the "Deployments" section at the bottom of this PR:

- Look for the section with the 🚀 rocket icon that says "This branch was successfully deployed."
- Alternatively, look for "github-actions bot deployed to preview" in the timeline.
- Click "View deployment" to open the preview URL.
</details>
