### PR TITLE
Improve SQL editor completion performance for large documents

### DIFF
--- a/tests/unit/__mocks__/flowscope-client.ts
+++ b/tests/unit/__mocks__/flowscope-client.ts
@@ -18,6 +18,7 @@ export class CancelledError extends Error {
 }
 
 let clientInstance: MockFlowScopeClient | null = null;
+let completionClientInstance: MockFlowScopeClient | null = null;
 
 export function getFlowScopeClient(): MockFlowScopeClient {
   if (!clientInstance) {
@@ -26,8 +27,16 @@ export function getFlowScopeClient(): MockFlowScopeClient {
   return clientInstance;
 }
 
-export function terminateFlowScopeClient(): void {
+export function getCompletionClient(): MockFlowScopeClient {
+  if (!completionClientInstance) {
+    completionClientInstance = createMockFlowScopeClient();
+  }
+  return completionClientInstance;
+}
+
+export function terminateFlowScopeClients(): void {
   clientInstance = null;
+  completionClientInstance = null;
 }
 
 export type FlowScopeClient = MockFlowScopeClient;


### PR DESCRIPTION
## Summary

- **Dedicated completion worker**: `completionItems()` runs on a separate Web Worker so it is never blocked by `split()`/`analyze()` operations on the main worker (which take 1-8s on 200KB+ documents)
- **Incremental span tracking**: adjusts statement boundaries on each keystroke without re-parsing the full document, providing instant highlighting and completion context
- **Local semicolon scanning**: fast fallback for statement extraction when no parsed spans are available, avoiding sending multi-MB documents to the completion engine
- **Large document guards (>50KB)**: skips expensive full-document operations in code lens, linked editing, hover, folding, and document symbol providers
- **Deferred deltaDecorations**: wraps highlight updates in coalesced `requestAnimationFrame` to avoid recursive deltaDecorations crash from Monaco's `onDidChangeModelContent`

## Test plan

- [ ] Open a large SQL script (200KB+) and verify autocomplete responds within ~1s
- [ ] Verify keyword completions (e.g. `SEL` → `SELECT`) work in large scripts
- [ ] Verify table/schema completions work in `FROM` clause in large scripts
- [ ] Verify statement highlighting updates immediately while typing
- [ ] Verify no console errors about recursive deltaDecorations
- [ ] Verify autocomplete still works normally in small scripts
- [ ] Verify code lens, hover, and linked editing work in small scripts
- [ ] Open a 4MB+ SQL file and verify the editor remains responsive