### PR TITLE
fix: Improve table alignment and theme consistency in UI

### DIFF
--- a/src/components/polly-demo-banner/polly-demo-banner.tsx
+++ b/src/components/polly-demo-banner/polly-demo-banner.tsx
@@ -59,7 +59,7 @@ export function PollyDemoBanner({
     return (
       <Alert
         icon={<IconSparkles size={14} />}
-        color="blue"
+        color="background-accent"
         variant="light"
         withCloseButton
         closeButtonLabel="Dismiss"
@@ -91,12 +91,13 @@ export function PollyDemoBanner({
     <Alert
       icon={<IconSparkles size={16} />}
       title="Welcome to Polly AI"
-      color="blue"
+      color="background-accent"
       variant="light"
       withCloseButton
       closeButtonLabel="Dismiss"
       onClose={handleDismiss}
       className={className}
+      classNames={{ title: 'text-textPrimary-light dark:text-textPrimary-dark' }}
     >
       <Text size="sm" mb="sm">
         You&apos;re using Polly, PondPilot&apos;s built-in AI assistant. It&apos;s ready to help
@@ -110,6 +111,7 @@ export function PollyDemoBanner({
         <Button
           size="xs"
           variant="filled"
+          color="background-accent"
           leftSection={<IconSettings size={14} />}
           onClick={handleConfigureByok}
         >

--- a/src/components/table/components/table-body/components/table-cell.tsx
+++ b/src/components/table/components/table-body/components/table-cell.tsx
@@ -68,8 +68,10 @@ export const TableRegularCell = memo(
           ref={cellRef}
           data-testid={setDataTestId(`data-table-cell-value-${cell.column.id}-${cell.row.index}`)}
           className={cn(
-            'text-sm p-2 overflow-hidden text-ellipsis whitespace-nowrap',
-            isNumberType(columnValueSqlType) && 'justify-end font-mono flex w-full',
+            'text-sm overflow-hidden text-ellipsis whitespace-nowrap',
+            isNumberType(columnValueSqlType)
+              ? 'justify-end font-mono flex w-full py-2 pl-2 pr-7'
+              : 'p-2',
             fValueType !== 'regular' &&
               'italic text-textSecondary-light dark:text-textSecondary-dark',
           )}

--- a/src/components/table/components/thead-cell/thead-cell.tsx
+++ b/src/components/table/components/thead-cell/thead-cell.tsx
@@ -2,7 +2,6 @@
 import { IconType, NamedIcon } from '@components/named-icon';
 import { getIconTypeForSQLType } from '@components/named-icon/utils';
 import { ColumnMeta } from '@components/table/model';
-import { Text } from '@mantine/core';
 import { ColumnSortSpec, DataRow } from '@models/db';
 import { IconTriangleInvertedFilled } from '@tabler/icons-react';
 import { Header, Table as TableType } from '@tanstack/react-table';
@@ -61,9 +60,7 @@ const THeadTitle = ({
           <NamedIcon iconType={iconType} size={16} />
         </div>
       )}
-      <Text truncate="end" fw={500}>
-        {header.isPlaceholder ? null : columnName}
-      </Text>
+      <span className="truncate font-medium">{header.isPlaceholder ? null : columnName}</span>
       {!isIndex && (
         <div
           className={cn(
@@ -152,7 +149,7 @@ export const TableHeadCell = memo(
       <div
         data-testid={setDataTestId(`data-table-header-cell-container-${header.column.id}`)}
         className={cn(
-          'relative z-10 flex items-center justify-between gap-1 px-4 py-[11px] h-[40px] text-sm font-medium text-textPrimary-light dark:text-textPrimary-dark whitespace-nowrap select-none border-transparent',
+          'relative z-10 flex items-center justify-between gap-1 pl-2 pr-4 py-[11px] h-[40px] text-sm font-medium text-textPrimary-light dark:text-textPrimary-dark whitespace-nowrap select-none border-transparent',
           'border-borderLight-light dark:border-borderLight-dark border-r',
           index === 0 && 'rounded-tl-xl border-l-0',
           index === totalHeaders - 1 && 'rounded-tr-xl border-r-0',

--- a/src/features/editor/hooks.tsx
+++ b/src/features/editor/hooks.tsx
@@ -103,8 +103,8 @@ export const useEditorTheme = (colorSchemeDark: boolean) => {
       ].filter(Boolean),
       colors: {
         'editor.background': normalizeThemeColor(
-          colorSchemeDark ? colors['brandBlue_neon-50'][0] : colors['grey-50'][0],
-          colorSchemeDark ? '#111111' : '#fdfdfd',
+          colorSchemeDark ? colors['blue-grey-800'][0] : colors['grey-50'][0],
+          colorSchemeDark ? '#242B35' : '#fdfdfd',
         ),
         'editor.foreground': normalizeThemeColor(
           colors['text-primary'][0],

--- a/src/pages/settings-page/components/ai-settings/ai-settings.tsx
+++ b/src/pages/settings-page/components/ai-settings/ai-settings.tsx
@@ -233,7 +233,7 @@ export const AISettings = () => {
               <Badge
                 key={provider.id}
                 variant="filled"
-                color="blue"
+                color="background-accent"
                 leftSection={<IconSparkles size={12} />}
                 size="sm"
               >
@@ -385,7 +385,7 @@ export const AISettings = () => {
         </Stack>
       ) : currentProvider && isPolly ? (
         /* Polly AI - show info instead of model selector */
-        <Alert icon={<IconSparkles size={16} />} color="blue" variant="light">
+        <Alert icon={<IconSparkles size={16} />} color="background-accent" variant="light">
           <Text size="sm">
             <strong>Polly</strong> is PondPilot&apos;s built-in AI assistant, ready to help with
             your SQL queries. No configuration required!

--- a/src/pages/settings-page/components/editor-settings/sql-preview.tsx
+++ b/src/pages/settings-page/components/editor-settings/sql-preview.tsx
@@ -89,9 +89,6 @@ export const SqlPreview = ({ fontSize, fontWeight = 'regular' }: SqlPreviewProps
       style={{
         width: '205px',
         height: '213px',
-        boxShadow: isDark
-          ? 'inset -16px 0px 9px rgba(56, 66, 82, 0.6)'
-          : 'inset -16px 0px 9px rgba(242, 244, 248, 0.7)',
       }}
     >
       <Box


### PR DESCRIPTION
## Summary

Several small UI fixes around table alignment, themed components, and editor look:

- **Data table alignment** — numeric column values were shifted ~20px right of their header text; non-numeric column headers were ~28px right of their cell content. Fixed via right-padding numeric cells and reducing left padding on the header.
- **Selected header contrast** — in light theme, the column name text in a selected (clicked) header rendered black on dark accent background. Replaced Mantine `<Text>` with a plain `<span>` so it inherits the parent's contrast color class.
- **AI Assistant settings** — Welcome Polly Alert, Configure API Key Button, "Polly is..." Alert, and "POLLY AI: BUILT-IN" Badge were rendering with Mantine's default blue. Switched to `color="background-accent"` to match the app's brand purple, in line with the existing Privacy Notice block.
- **Welcome Polly title contrast** — title rendered in accent color, blending with the dark accent background in dark theme. Overridden via `classNames={{ title: ... }}` to use the regular text color.
- **SQL editor background (dark)** — was `#111111` (near-black), causing it to stand out as a darker rectangle vs. the rest of the UI. Now uses `blue-grey-800` (`#242B35`), matching `background-primary`.
- **SQL Editor Font preview** — removed the unused inset right-edge shadow.

## Test plan

- [ ] Run `CREATE TABLE emp_new (id int, name varchar, age int)` + insert + `SELECT *`. Verify in both themes:
  - [ ] Numeric columns (`id`, `age`): header text right edge aligns with cell value right edge.
  - [ ] Text column (`name`): header content (icon `aA` left edge) aligns with cell text left edge.
  - [ ] `#` index column unchanged.
- [ ] Click a column header in light theme → text becomes white on accent background (high contrast).
- [ ] Click a column header in dark theme → unchanged (still readable).
- [ ] Open Settings → AI Assistant. All Polly-related Alerts/Badge/Button match Privacy Notice purple in both themes; Welcome title is readable in dark theme.
- [ ] Open Settings → Appearance → SQL Editor Font. No inset shadow on the right of the preview.
- [ ] In dark theme, query editor background blends with surrounding tab bar / side panel.