### PR TITLE
Add Quack protocol integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ tests/test-tmp
 
 # Local module cahce
 .module-cache
+.local-bin/
 
 *.local.*
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@duckdb/duckdb-wasm": "1.33.1-dev20.0",
+    "@duckdb/duckdb-wasm": "1.33.1-dev53.0",
     "@hello-pangea/dnd": "^17.0.0",
     "@mantine/core": "^8.2.3",
     "@mantine/hooks": "^8.2.3",

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -46,6 +46,7 @@ import {
   isIcebergCatalog,
   isLocalDatabase,
   isMotherDuckConnection,
+  isQuackConnection,
   isRemoteDatabase,
 } from '@utils/data-source';
 import { fileSystemService } from '@utils/file-system-adapter';
@@ -303,7 +304,11 @@ export const SpotlightMenu = () => {
         continue;
       }
 
-      if (isLocalDatabase(dataSource) || isRemoteDatabase(dataSource)) {
+      if (
+        isLocalDatabase(dataSource) ||
+        isRemoteDatabase(dataSource) ||
+        isQuackConnection(dataSource)
+      ) {
         // For databases we need to read all tables and views from metadata
         const dbMetadata = databaseMetadata.get(dataSource.dbName);
         const isSystemDatabase =

--- a/src/controllers/data-source/data-view-source.ts
+++ b/src/controllers/data-source/data-view-source.ts
@@ -247,6 +247,22 @@ export const deleteDataSources = async (
       continue;
     }
 
+    if (dataSource.type === 'quack') {
+      detachAndUnregisterDatabase(conn, dataSource.dbName, dataSource.uri);
+      if (dataSource.secretRef) {
+        try {
+          const { _iDbConn } = useAppStore.getState();
+          if (_iDbConn) {
+            const { deleteSecret } = await import('@services/secret-store');
+            await deleteSecret(_iDbConn, dataSource.secretRef);
+          }
+        } catch (storeError) {
+          console.warn('Failed to delete Quack secret from store during deletion:', storeError);
+        }
+      }
+      continue;
+    }
+
     if (dataSource.type === 'ducklake-catalog') {
       // For DuckLake catalogs, just detach
       try {

--- a/src/controllers/file-explorer.ts
+++ b/src/controllers/file-explorer.ts
@@ -30,6 +30,7 @@ export const renameFile = async (
     dataSource.type === 'remote-db' ||
     dataSource.type === 'iceberg-catalog' ||
     dataSource.type === 'ducklake-catalog' ||
+    dataSource.type === 'quack' ||
     dataSource.type === 'motherduck'
   ) {
     throw new Error(`File source ${fileDataSourceId} not found`);
@@ -149,6 +150,7 @@ export const renameXlsxFile = async (
       ds.type !== 'remote-db' &&
       ds.type !== 'iceberg-catalog' &&
       ds.type !== 'ducklake-catalog' &&
+      ds.type !== 'quack' &&
       ds.type !== 'motherduck' &&
       ds.fileSourceId === localEntryId,
   );

--- a/src/controllers/file-system/file-system-controller.ts
+++ b/src/controllers/file-system/file-system-controller.ts
@@ -505,6 +505,7 @@ export const deleteLocalFileOrFolders = (conn: AsyncDuckDBConnectionPool, ids: L
       dataSource.type === 'remote-db' ||
       dataSource.type === 'iceberg-catalog' ||
       dataSource.type === 'ducklake-catalog' ||
+      dataSource.type === 'quack' ||
       dataSource.type === 'motherduck'
     ) {
       continue;
@@ -681,6 +682,7 @@ export const syncFiles = async (conn: AsyncDuckDBConnectionPool) => {
         dataSource.type !== 'remote-db' &&
         dataSource.type !== 'iceberg-catalog' &&
         dataSource.type !== 'ducklake-catalog' &&
+        dataSource.type !== 'quack' &&
         dataSource.type !== 'motherduck' &&
         localFileIdsToDelete.has(dataSource.fileSourceId)
       ) {

--- a/src/controllers/tab/pure.ts
+++ b/src/controllers/tab/pure.ts
@@ -8,6 +8,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
 } from '@models/data-source';
 import { SQLScriptId } from '@models/sql-script';
@@ -34,7 +35,13 @@ import {
 
 export const findTabFromLocalDBObjectImpl = (
   tabs: Map<TabId, AnyTab>,
-  dataSource: LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | MotherDuckConnection,
+  dataSource:
+    | LocalDB
+    | RemoteDB
+    | IcebergCatalog
+    | DuckLakeCatalog
+    | QuackConnection
+    | MotherDuckConnection,
   schemaName: string,
   objectName: string,
   databaseName?: string,

--- a/src/controllers/tab/tab-controller.ts
+++ b/src/controllers/tab/tab-controller.ts
@@ -10,6 +10,7 @@ import {
   LocalDB,
   MotherDuckConnection,
   PersistentDataSourceId,
+  QuackConnection,
   RemoteDB,
 } from '@models/data-source';
 import { ColumnSortSpecList } from '@models/db';
@@ -250,6 +251,7 @@ export const getOrCreateTabFromLocalDBObject = (
     | RemoteDB
     | IcebergCatalog
     | DuckLakeCatalog
+    | QuackConnection
     | MotherDuckConnection
     | PersistentDataSourceId,
   schemaName: string,
@@ -527,6 +529,7 @@ export const findTabFromLocalDBObject = (
     | RemoteDB
     | IcebergCatalog
     | DuckLakeCatalog
+    | QuackConnection
     | MotherDuckConnection
     | PersistentDataSourceId,
   schemaName: string,
@@ -998,6 +1001,7 @@ function updateTabLRUTracking(tabId: TabId): void {
           dataSource.type === 'remote-db' ||
           dataSource.type === 'iceberg-catalog' ||
           dataSource.type === 'ducklake-catalog' ||
+          dataSource.type === 'quack' ||
           dataSource.type === 'motherduck')
       ) {
         // For MotherDuck, use per-database identifier instead of the bare prefix,

--- a/src/features/app-context/hooks/use-init-application.tsx
+++ b/src/features/app-context/hooks/use-init-application.tsx
@@ -7,6 +7,7 @@ import {
   useDuckDBConnectionPool,
   useDuckDBInitializer,
 } from '@features/duckdb-context/duckdb-context';
+import { AnyDataSource } from '@models/data-source';
 import { useAppStore, setAppLoadState } from '@store/app-store';
 import { restoreAppDataFromIDB } from '@store/restore';
 import { MaxRetriesExceededError } from '@utils/connection-errors';
@@ -16,6 +17,7 @@ import {
   isIcebergCatalog,
   isDuckLakeCatalog,
   isMotherDuckConnection,
+  isQuackConnection,
 } from '@utils/data-source';
 import {
   attachAndVerifyDuckLakeCatalog,
@@ -31,6 +33,11 @@ import {
   reconnectMotherDuck,
   updateMotherDuckConnectionState,
 } from '@utils/motherduck';
+import {
+  resolveQuackToken,
+  reconnectQuackConnection,
+  updateQuackConnectionState,
+} from '@utils/quack';
 import { updateRemoteDbConnectionState } from '@utils/remote-database';
 import { sanitizeErrorMessage } from '@utils/sanitize-error';
 import { buildAttachQuery } from '@utils/sql-builder';
@@ -43,7 +50,20 @@ async function reconnectRemoteDatabases(conn: AsyncDuckDBConnectionPool): Promis
   const { dataSources, _iDbConn } = useAppStore.getState();
   const connectedDatabases: string[] = [];
 
-  for (const [id, dataSource] of dataSources) {
+  // MotherDuck must initialize before Quack when both are restored on startup.
+  // The current DuckDB-WASM/MotherDuck extension can fail with
+  // "InMemory not implemented yet" if Quack has already been loaded in the
+  // same engine instance. Preserve normal insertion order otherwise.
+  const getReconnectPriority = (dataSource: AnyDataSource): number => {
+    if (isMotherDuckConnection(dataSource)) return 0;
+    if (isQuackConnection(dataSource)) return 2;
+    return 1;
+  };
+  const orderedDataSources = Array.from(dataSources).sort(
+    ([, left], [, right]) => getReconnectPriority(left) - getReconnectPriority(right),
+  );
+
+  for (const [id, dataSource] of orderedDataSources) {
     if (isIcebergCatalog(dataSource)) {
       // Resolve credentials from secret store (or inline fallback)
       const credentials = _iDbConn ? await resolveIcebergCredentials(_iDbConn, dataSource) : null;
@@ -120,6 +140,25 @@ async function reconnectRemoteDatabases(conn: AsyncDuckDBConnectionPool): Promis
         const sanitized = sanitizeErrorMessage(errorMessage);
         console.warn(`Failed to reconnect DuckLake catalog ${dataSource.catalogAlias}:`, sanitized);
         updateDuckLakeConnectionState(id, 'error', sanitized);
+      }
+      continue;
+    }
+
+    if (isQuackConnection(dataSource)) {
+      const token = _iDbConn ? await resolveQuackToken(_iDbConn, dataSource) : null;
+
+      if (!token) {
+        updateQuackConnectionState(id, 'credentials-required');
+        continue;
+      }
+
+      try {
+        await reconnectQuackConnection(conn, dataSource, token);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const sanitized = sanitizeErrorMessage(errorMessage);
+        console.warn(`Failed to reconnect Quack database ${dataSource.dbName}:`, sanitized);
+        updateQuackConnectionState(id, 'error', sanitized);
       }
       continue;
     }

--- a/src/features/comparison/components/comparison-results/comparison-viewer.tsx
+++ b/src/features/comparison/components/comparison-results/comparison-viewer.tsx
@@ -910,11 +910,16 @@ export const ComparisonViewer = ({
     // Find the data source by database name
     const dataSource = Array.from(dataSources.values()).find(
       (ds) =>
-        (ds.type === 'remote-db' || ds.type === 'attached-db') &&
+        (ds.type === 'remote-db' || ds.type === 'attached-db' || ds.type === 'quack') &&
         ds.dbName === sourceA.databaseName,
     );
 
-    if (dataSource && (dataSource.type === 'remote-db' || dataSource.type === 'attached-db')) {
+    if (
+      dataSource &&
+      (dataSource.type === 'remote-db' ||
+        dataSource.type === 'attached-db' ||
+        dataSource.type === 'quack')
+    ) {
       // Look up the object type from database metadata
       const dbMetadata = databaseMetadata.get(dataSource.dbName);
       const schemaName = sourceA.schemaName || 'main';
@@ -934,11 +939,16 @@ export const ComparisonViewer = ({
     // Find the data source by database name
     const dataSource = Array.from(dataSources.values()).find(
       (ds) =>
-        (ds.type === 'remote-db' || ds.type === 'attached-db') &&
+        (ds.type === 'remote-db' || ds.type === 'attached-db' || ds.type === 'quack') &&
         ds.dbName === sourceB.databaseName,
     );
 
-    if (dataSource && (dataSource.type === 'remote-db' || dataSource.type === 'attached-db')) {
+    if (
+      dataSource &&
+      (dataSource.type === 'remote-db' ||
+        dataSource.type === 'attached-db' ||
+        dataSource.type === 'quack')
+    ) {
       // Look up the object type from database metadata
       const dbMetadata = databaseMetadata.get(dataSource.dbName);
       const schemaName = sourceB.schemaName || 'main';

--- a/src/features/comparison/utils/source-selection.ts
+++ b/src/features/comparison/utils/source-selection.ts
@@ -21,6 +21,7 @@ export function dataSourceToComparisonSource(
     dataSource.type === 'remote-db' ||
     dataSource.type === 'iceberg-catalog' ||
     dataSource.type === 'ducklake-catalog' ||
+    dataSource.type === 'quack' ||
     dataSource.type === 'motherduck'
   ) {
     if (!schemaName || !tableName) {

--- a/src/features/data-explorer/builders/database-tree-builder.ts
+++ b/src/features/data-explorer/builders/database-tree-builder.ts
@@ -1,3 +1,4 @@
+import { showError } from '@components/app-notifications';
 import { TreeNodeData, TreeNodeMenuItemType } from '@components/explorer-tree';
 import { deleteDataSources } from '@controllers/data-source';
 import { renameDB } from '@controllers/db-explorer';
@@ -9,6 +10,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
 } from '@models/data-source';
 import { DataBaseModel } from '@models/db';
@@ -25,6 +27,7 @@ import {
   listMotherDuckDatabases,
 } from '@utils/motherduck';
 import { getLocalDBDataSourceName } from '@utils/navigation';
+import { disconnectQuackConnection, refreshQuackMetadata } from '@utils/quack';
 import { reconnectRemoteDatabase, disconnectRemoteDatabase } from '@utils/remote-database';
 
 import { DataExplorerNodeMap, DataExplorerNodeTypeMap } from '../model';
@@ -72,12 +75,12 @@ interface DatabaseTreeBuilderContext {
  * @returns TreeNodeData configured as a complete database node with all children
  */
 export function buildDatabaseNode(
-  dataSource: LocalDB | RemoteDB,
+  dataSource: LocalDB | RemoteDB | QuackConnection,
   isSystemDb: boolean,
   context: DatabaseTreeBuilderContext,
 ): TreeNodeData<DataExplorerNodeTypeMap> {
   const { id: dbId, dbName } = dataSource;
-  const isRemoteDb = dataSource.type === 'remote-db';
+  const isRemoteDb = dataSource.type === 'remote-db' || dataSource.type === 'quack';
   const {
     nodeMap,
     anyNodeIdToNodeTypeMap,
@@ -107,7 +110,7 @@ export function buildDatabaseNode(
 
   // For remote databases, append connection state indicator
   if (isRemoteDb) {
-    const remoteDb = dataSource as RemoteDB;
+    const remoteDb = dataSource as RemoteDB | QuackConnection;
     const stateIcon =
       remoteDb.connectionState === 'connected'
         ? '✓'
@@ -168,30 +171,49 @@ export function buildDatabaseNode(
         {
           label: 'Copy URL',
           onClick: () => {
-            copyToClipboard((dataSource as RemoteDB).url, {
-              showNotification: true,
-              notificationTitle: 'URL Copied',
-            });
+            copyToClipboard(
+              dataSource.type === 'quack' ? dataSource.uri : (dataSource as RemoteDB).url,
+              {
+                showNotification: true,
+                notificationTitle: 'URL Copied',
+              },
+            );
           },
         },
         {
-          label: (dataSource as RemoteDB).connectionState === 'connected' ? 'Refresh' : 'Reconnect',
+          label:
+            (dataSource as RemoteDB | QuackConnection).connectionState === 'connected'
+              ? 'Refresh'
+              : 'Reconnect',
           onClick: async () => {
-            if ((dataSource as RemoteDB).connectionState === 'connected') {
+            if ((dataSource as RemoteDB | QuackConnection).connectionState === 'connected') {
               // Refresh metadata
-              await refreshDatabaseMetadata(conn, [dbName]);
+              if (dataSource.type === 'quack') {
+                await refreshQuackMetadata(conn, dataSource);
+              } else {
+                await refreshDatabaseMetadata(conn, [dbName]);
+              }
+            } else if (dataSource.type === 'quack') {
+              showError({
+                title: 'Reconnect unavailable',
+                message: 'Reload PondPilot or add the Quack server again to reconnect.',
+              });
             } else {
               // Attempt reconnection
               await reconnectRemoteDatabase(conn, dataSource as RemoteDB);
             }
           },
         },
-        ...((dataSource as RemoteDB).connectionState === 'connected'
+        ...((dataSource as RemoteDB | QuackConnection).connectionState === 'connected'
           ? [
               {
                 label: 'Disconnect',
                 onClick: async () => {
-                  await disconnectRemoteDatabase(conn, dataSource as RemoteDB);
+                  if (dataSource.type === 'quack') {
+                    await disconnectQuackConnection(conn, dataSource);
+                  } else {
+                    await disconnectRemoteDatabase(conn, dataSource as RemoteDB);
+                  }
                 },
               },
             ]

--- a/src/features/data-explorer/data-explorer.tsx
+++ b/src/features/data-explorer/data-explorer.tsx
@@ -211,6 +211,7 @@ export const DataExplorer = memo(() => {
           !dataSource ||
           (dataSource.type !== 'attached-db' &&
             dataSource.type !== 'remote-db' &&
+            dataSource.type !== 'quack' &&
             dataSource.type !== 'iceberg-catalog' &&
             dataSource.type !== 'ducklake-catalog' &&
             dataSource.type !== 'motherduck')

--- a/src/features/data-explorer/hooks/use-build-nodes.ts
+++ b/src/features/data-explorer/hooks/use-build-nodes.ts
@@ -5,6 +5,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
 } from '@models/data-source';
 
@@ -19,7 +20,7 @@ import { useSystemDbNode } from './use-system-db-node';
 type UseBuildNodesProps = {
   systemDatabase: LocalDB | undefined;
   localDatabases: LocalDB[];
-  remoteDatabases: RemoteDB[];
+  remoteDatabases: Array<RemoteDB | QuackConnection>;
   icebergCatalogs: IcebergCatalog[];
   duckLakeCatalogs: DuckLakeCatalog[];
   motherduckConnections: MotherDuckConnection[];

--- a/src/features/data-explorer/hooks/use-database-separation.ts
+++ b/src/features/data-explorer/hooks/use-database-separation.ts
@@ -3,6 +3,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
   SYSTEM_DATABASE_ID,
   AnyDataSource,
@@ -13,7 +14,7 @@ export const useDatabaseSeparation = (allDataSources: Map<string, AnyDataSource>
   return useMemo(() => {
     let systemDb: LocalDB | undefined;
     const localDbs: LocalDB[] = [];
-    const remoteDbs: RemoteDB[] = [];
+    const remoteDbs: Array<RemoteDB | QuackConnection> = [];
     const icebergCatalogs: IcebergCatalog[] = [];
     const duckLakeCatalogs: DuckLakeCatalog[] = [];
     const motherduckConnections: MotherDuckConnection[] = [];
@@ -25,7 +26,7 @@ export const useDatabaseSeparation = (allDataSources: Map<string, AnyDataSource>
         } else {
           localDbs.push(dataSource);
         }
-      } else if (dataSource.type === 'remote-db') {
+      } else if (dataSource.type === 'remote-db' || dataSource.type === 'quack') {
         remoteDbs.push(dataSource);
       } else if (dataSource.type === 'iceberg-catalog') {
         icebergCatalogs.push(dataSource);

--- a/src/features/data-explorer/hooks/use-remote-db-nodes.ts
+++ b/src/features/data-explorer/hooks/use-remote-db-nodes.ts
@@ -1,13 +1,13 @@
 import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
 import { Comparison } from '@models/comparison';
-import { RemoteDB } from '@models/data-source';
+import { QuackConnection, RemoteDB } from '@models/data-source';
 import { useMemo } from 'react';
 
 import { buildDatabaseNode } from '../builders/database-tree-builder';
 import { DataExplorerNodeMap } from '../model';
 
 type UseRemoteDbNodesProps = {
-  remoteDatabases: RemoteDB[];
+  remoteDatabases: Array<RemoteDB | QuackConnection>;
   nodeMap: DataExplorerNodeMap;
   anyNodeIdToNodeTypeMap: Map<string, any>;
   conn: AsyncDuckDBConnectionPool;

--- a/src/features/datasource-wizard/components/quack-config.tsx
+++ b/src/features/datasource-wizard/components/quack-config.tsx
@@ -1,0 +1,230 @@
+import { showError, showSuccess } from '@components/app-notifications';
+import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Group,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { useInputState } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { deleteSecret, makeSecretId, putSecret, SecretId } from '@services/secret-store';
+import { useAppStore } from '@store/app-store';
+import { IconAlertCircle } from '@tabler/icons-react';
+import {
+  attachQuackConnection,
+  getQuackDatabaseModel,
+  makeQuackConnection,
+  persistQuackConnection,
+  validateQuackUri,
+} from '@utils/quack';
+import { setDataTestId } from '@utils/test-id';
+import { useState } from 'react';
+
+interface QuackConfigProps {
+  pool: AsyncDuckDBConnectionPool | null;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+export function QuackConfig({ pool, onBack, onClose }: QuackConfigProps) {
+  const [uri, setUri] = useInputState('');
+  const [dbName, setDbName] = useInputState('');
+  const [token, setToken] = useInputState('');
+  const [disableSsl, setDisableSsl] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+
+  const validateForm = (): boolean => {
+    const uriValidation = validateQuackUri(uri);
+    if (!uriValidation.isValid) {
+      notifications.clean();
+      showError({ title: 'Invalid Quack URI', message: uriValidation.error ?? 'Invalid URI' });
+      return false;
+    }
+    if (!dbName.trim()) {
+      showError({ title: 'Database name required', message: 'Please enter a database alias' });
+      return false;
+    }
+    if (!token.trim()) {
+      showError({
+        title: 'Token required',
+        message: 'Please enter the Quack authentication token',
+      });
+      return false;
+    }
+    return true;
+  };
+
+  const handleTest = async () => {
+    if (!pool || isTesting || isLoading) return;
+    if (!validateForm()) return;
+
+    setIsTesting(true);
+    try {
+      await attachQuackConnection({
+        pool,
+        uri: uri.trim(),
+        dbName: dbName.trim(),
+        token,
+        disableSsl,
+      });
+      await pool.query(`DETACH DATABASE IF EXISTS "${dbName.trim().replace(/"/g, '""')}"`);
+      showSuccess({ title: 'Connection successful', message: 'Quack connection test passed' });
+    } catch (error) {
+      showError({
+        title: 'Connection failed',
+        message: error instanceof Error ? error.message : String(error),
+        autoClose: false,
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!pool) {
+      showError({ title: 'App not ready', message: 'Please wait for the app to initialize' });
+      return;
+    }
+    if (!validateForm()) return;
+
+    let secretRef: SecretId | null = null;
+    let secretPersisted = false;
+
+    setIsLoading(true);
+    try {
+      const { dataSources, databaseMetadata, _iDbConn } = useAppStore.getState();
+      if (!_iDbConn) throw new Error('Encrypted secret store is not available');
+
+      secretRef = makeSecretId();
+      await putSecret(_iDbConn, secretRef, {
+        label: `Quack: ${dbName.trim()}`,
+        data: { token },
+      });
+      secretPersisted = true;
+
+      const quack = makeQuackConnection({
+        uri: uri.trim(),
+        dbName: dbName.trim(),
+        secretRef,
+        disableSsl,
+      });
+
+      await attachQuackConnection({
+        pool,
+        uri: quack.uri,
+        dbName: quack.dbName,
+        token,
+        disableSsl: quack.disableSsl,
+      });
+
+      const connected = { ...quack, connectionState: 'connected' as const };
+      const newDataSources = new Map(dataSources);
+      newDataSources.set(connected.id, connected);
+
+      const remoteMetadata = await getQuackDatabaseModel(pool, connected.dbName);
+      const newMetadata = new Map(databaseMetadata);
+      for (const [remoteDbName, dbModel] of remoteMetadata) newMetadata.set(remoteDbName, dbModel);
+
+      useAppStore.setState(
+        { dataSources: newDataSources, databaseMetadata: newMetadata },
+        false,
+        'DatasourceWizard/addQuack',
+      );
+      await persistQuackConnection(connected);
+
+      showSuccess({ title: 'Quack server added', message: `Connected to '${connected.dbName}'` });
+      onClose();
+    } catch (error) {
+      const { _iDbConn } = useAppStore.getState();
+      if (secretPersisted && secretRef && _iDbConn) {
+        try {
+          await deleteSecret(_iDbConn, secretRef);
+        } catch (cleanupError) {
+          console.warn('Failed to clean up Quack secret after connection failure:', cleanupError);
+        }
+      }
+      showError({
+        title: 'Failed to add Quack server',
+        message: error instanceof Error ? error.message : String(error),
+        autoClose: false,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Stack gap={16}>
+      <Text size="sm" c="text-secondary" className="pl-4">
+        Connect to a live DuckDB server using the Quack protocol
+      </Text>
+
+      <Alert icon={<IconAlertCircle size={16} />} color="background-accent" className="text-sm">
+        Browser clients require HTTPS and CORS for remote hosts. Use Disable SSL only for local or
+        trusted development servers.
+      </Alert>
+
+      <Stack gap={12}>
+        <TextInput
+          label="Quack URI"
+          data-testid={setDataTestId('quack-uri-input')}
+          placeholder="quack:localhost:9494"
+          value={uri}
+          onChange={setUri}
+          required
+        />
+        <TextInput
+          label="Database Name"
+          data-testid={setDataTestId('quack-database-name-input')}
+          placeholder="remote_duckdb"
+          value={dbName}
+          onChange={setDbName}
+          required
+        />
+        <PasswordInput
+          label="Token"
+          data-testid={setDataTestId('quack-token-input')}
+          placeholder="Quack authentication token"
+          value={token}
+          onChange={(event) => setToken(event.currentTarget.value)}
+          required
+        />
+        <Checkbox
+          label="Disable SSL (local/dev only)"
+          checked={disableSsl}
+          onChange={(event) => setDisableSsl(event.currentTarget.checked)}
+          className="pl-4"
+        />
+      </Stack>
+
+      <Group justify="end" className="mt-4">
+        <Button variant="transparent" onClick={onBack}>
+          Cancel
+        </Button>
+        <Button
+          variant="outline"
+          onClick={handleTest}
+          loading={isTesting}
+          disabled={!uri.trim() || !dbName.trim() || !token.trim() || isLoading}
+          data-testid={setDataTestId('test-quack-connection-button')}
+        >
+          Test Connection
+        </Button>
+        <Button
+          onClick={handleAdd}
+          loading={isLoading || isTesting}
+          disabled={!uri.trim() || !dbName.trim() || !token.trim() || isTesting}
+          data-testid={setDataTestId('add-quack-button')}
+        >
+          Add Quack Server
+        </Button>
+      </Group>
+    </Stack>
+  );
+}

--- a/src/features/datasource-wizard/components/remote-database-config.tsx
+++ b/src/features/datasource-wizard/components/remote-database-config.tsx
@@ -287,7 +287,7 @@ export function RemoteDatabaseConfig({ onBack, onClose, pool }: RemoteDatabaseCo
   return (
     <Stack gap={16}>
       <Text size="sm" c="text-secondary" className="pl-4">
-        Connect to a remote database using a URL
+        Remote database files and URLs
       </Text>
 
       <Alert
@@ -296,7 +296,7 @@ export function RemoteDatabaseConfig({ onBack, onClose, pool }: RemoteDatabaseCo
         className="text-sm"
         classNames={{ icon: 'mr-1' }}
       >
-        Supported protocols: HTTPS, S3, GCS (Google Cloud Storage), Azure Blob Storage
+        Supported storage: S3 compatible services (S3, GCS, Azure Blob Storage) and HTTPS
       </Alert>
 
       <Stack gap={12}>

--- a/src/features/datasource-wizard/components/remote-server-config.tsx
+++ b/src/features/datasource-wizard/components/remote-server-config.tsx
@@ -1,0 +1,44 @@
+import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
+import { SegmentedControl, Stack, Text } from '@mantine/core';
+import { setDataTestId } from '@utils/test-id';
+import { useState } from 'react';
+
+import { QuackConfig } from './quack-config';
+import { RemoteDatabaseConfig } from './remote-database-config';
+
+interface RemoteServerConfigProps {
+  pool: AsyncDuckDBConnectionPool | null;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+type RemoteServerKind = 's3-compatible' | 'quack';
+
+export function RemoteServerConfig({ pool, onBack, onClose }: RemoteServerConfigProps) {
+  const [kind, setKind] = useState<RemoteServerKind>('s3-compatible');
+
+  return (
+    <Stack gap={16}>
+      <Stack gap={8} className="px-4">
+        <Text size="sm" c="text-secondary">
+          Connect to remote DuckDB-compatible storage or a live DuckDB server
+        </Text>
+        <SegmentedControl
+          value={kind}
+          onChange={(value) => setKind(value as RemoteServerKind)}
+          data={[
+            { label: 'Files & URLs', value: 's3-compatible' },
+            { label: 'Quack', value: 'quack' },
+          ]}
+          data-testid={setDataTestId('remote-server-kind-selector')}
+        />
+      </Stack>
+
+      {kind === 's3-compatible' ? (
+        <RemoteDatabaseConfig onBack={onBack} onClose={onClose} pool={pool} />
+      ) : (
+        <QuackConfig onBack={onBack} onClose={onClose} pool={pool} />
+      )}
+    </Stack>
+  );
+}

--- a/src/features/datasource-wizard/datasource-wizard-modal.tsx
+++ b/src/features/datasource-wizard/datasource-wizard-modal.tsx
@@ -21,7 +21,8 @@ import { ClipboardImportConfig } from './components/clipboard-import-config';
 import { DuckLakeCatalogConfig } from './components/ducklake-catalog-config';
 import { IcebergCatalogConfig } from './components/iceberg-catalog-config';
 import { MotherDuckConfig } from './components/motherduck-config';
-import { RemoteDatabaseConfig } from './components/remote-database-config';
+import { QuackConfig } from './components/quack-config';
+import { RemoteServerConfig } from './components/remote-server-config';
 import { validateJSON, validateCSV } from './utils/clipboard-import';
 
 interface DatasourceWizardModalProps {
@@ -38,19 +39,22 @@ export type WizardStep =
   | 'iceberg-config'
   | 'ducklake-config'
   | 'motherduck-config'
+  | 'quack-config'
   | 'clipboard-csv'
   | 'clipboard-json';
 
 const getStepTitle = (step: WizardStep): string => {
   switch (step) {
     case 'remote-config':
-      return 'REMOTE DATABASE';
+      return 'REMOTE SERVER';
     case 'iceberg-config':
       return 'ICEBERG CATALOG';
     case 'ducklake-config':
       return 'DUCKLAKE CATALOG';
     case 'motherduck-config':
       return 'MOTHERDUCK';
+    case 'quack-config':
+      return 'QUACK SERVER';
     case 'clipboard-csv':
       return 'IMPORT CSV FROM CLIPBOARD';
     case 'clipboard-json':
@@ -374,8 +378,8 @@ export function DatasourceWizardModal({
           stroke={1.5}
         />
       ),
-      title: 'Remote Database',
-      description: 'S3, GCS, Azure, HTTPS',
+      title: 'Remote Server',
+      description: 'S3, HTTPS, Quack',
       testId: 'add-remote-database-card',
     },
     {
@@ -495,7 +499,7 @@ export function DatasourceWizardModal({
       )}
 
       {step === 'remote-config' && (
-        <RemoteDatabaseConfig onBack={handleBack} onClose={onClose} pool={pool} />
+        <RemoteServerConfig onBack={handleBack} onClose={onClose} pool={pool} />
       )}
 
       {step === 'iceberg-config' && (
@@ -509,6 +513,8 @@ export function DatasourceWizardModal({
       {step === 'motherduck-config' && (
         <MotherDuckConfig onBack={handleBack} onClose={onClose} pool={pool} />
       )}
+
+      {step === 'quack-config' && <QuackConfig onBack={handleBack} onClose={onClose} pool={pool} />}
 
       {(step === 'clipboard-csv' || step === 'clipboard-json') && (
         <ClipboardImportConfig

--- a/src/features/datasource-wizard/utils.tsx
+++ b/src/features/datasource-wizard/utils.tsx
@@ -18,7 +18,7 @@ export const useOpenDataWizardModal = () => {
         classNames: {
           content: cn(
             'bg-backgroundPrimary-light dark:bg-backgroundPrimary-dark rounded-2xl',
-            'max-w-4xl w-fit min-w-96',
+            'w-[56rem] max-w-[calc(100vw-2rem)] min-w-96',
           ),
           header: 'p-4 bg-backgroundPrimary-light dark:bg-backgroundPrimary-dark',
         },

--- a/src/features/duckdb-context/duckdb-context.tsx
+++ b/src/features/duckdb-context/duckdb-context.tsx
@@ -91,8 +91,36 @@ export const DuckDBConnectionPoolProvider = ({
   // Get persistence state from context
   const { persistenceState, updatePersistenceState } = useDuckDBPersistence();
 
-  // Use static cdn hosted bundles
-  const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+  // Use static cdn hosted bundles by default. Allow tests/preview builds to
+  // point at newer DuckDB-WASM artifacts before an npm package is published.
+  const JSDELIVR_BUNDLES = (() => {
+    const defaultBundles = duckdb.getJsDelivrBundles();
+    const mainModule = import.meta.env.VITE_DUCKDB_WASM_MAIN_MODULE;
+    const mainWorker = import.meta.env.VITE_DUCKDB_WASM_MAIN_WORKER;
+    const pthreadWorker = import.meta.env.VITE_DUCKDB_WASM_PTHREAD_WORKER;
+    const forceMvp = import.meta.env.VITE_DUCKDB_WASM_FORCE_MVP === 'true';
+
+    if (mainModule || mainWorker || pthreadWorker || forceMvp) {
+      const overriddenBundles: duckdb.DuckDBBundles = {
+        mvp: {
+          mainModule: mainModule || defaultBundles.mvp.mainModule,
+          mainWorker: mainWorker || defaultBundles.mvp.mainWorker,
+        },
+        ...(forceMvp
+          ? {}
+          : {
+              eh: {
+                mainModule: mainModule || defaultBundles.eh!.mainModule,
+                mainWorker: mainWorker || defaultBundles.eh!.mainWorker,
+                ...(pthreadWorker ? { pthreadWorker } : {}),
+              },
+            }),
+      };
+      return overriddenBundles;
+    }
+
+    return defaultBundles;
+  })();
 
   // create a logger
   const logger = new duckdb.ConsoleLogger(

--- a/src/features/schema-browser/utils/schema-processors/db-source-processor.ts
+++ b/src/features/schema-browser/utils/schema-processors/db-source-processor.ts
@@ -4,6 +4,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
   PersistentDataSourceId,
 } from '@models/data-source';
@@ -25,7 +26,7 @@ export async function processDbSource(
   pool: AsyncDuckDBConnectionPool,
   dbSources: Map<
     PersistentDataSourceId,
-    LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | MotherDuckConnection
+    LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | QuackConnection | MotherDuckConnection
   >,
   dbMetadata: Map<string, DataBaseModel>,
   abortSignal: AbortSignal,

--- a/src/hooks/use-beforeunload-protection.ts
+++ b/src/hooks/use-beforeunload-protection.ts
@@ -20,7 +20,7 @@ export function useBeforeUnloadProtection() {
       // Check if there are any file entries or file-based data sources
       const hasFiles = localEntries.size > 0;
       const hasFileDataSources = Array.from(dataSources.values()).some(
-        (ds) => ds.type !== 'attached-db' && ds.type !== 'remote-db',
+        (ds) => ds.type !== 'attached-db' && ds.type !== 'remote-db' && ds.type !== 'quack',
       );
 
       if (hasFiles || hasFileDataSources) {

--- a/src/models/data-source.ts
+++ b/src/models/data-source.ts
@@ -311,10 +311,53 @@ export interface DuckLakeCatalog {
 }
 
 /**
- * MotherDuck cloud database connection.
- * Account-level: a single token grants access to all user databases.
- * Databases are auto-discovered via DuckDB's catalog after connecting.
+ * Quack protocol connection to a live DuckDB server.
  */
+export interface QuackConnection {
+  readonly type: 'quack';
+  id: PersistentDataSourceId;
+
+  /**
+   * Quack endpoint URI, e.g. quack:localhost or quack:example.com:9494.
+   */
+  uri: string;
+
+  /**
+   * Database alias used in ATTACH ... AS.
+   */
+  dbName: string;
+
+  /**
+   * Connection state for handling network/auth issues.
+   */
+  connectionState: 'connected' | 'disconnected' | 'error' | 'connecting' | 'credentials-required';
+
+  /**
+   * Error message if connection failed.
+   */
+  connectionError?: string;
+
+  /**
+   * Timestamp of when this connection was established.
+   */
+  attachedAt: number;
+
+  /**
+   * Optional comment/description.
+   */
+  comment?: string;
+
+  /**
+   * Reference to encrypted secret-store entry holding the Quack token.
+   */
+  secretRef?: SecretId;
+
+  /**
+   * Disable SSL for non-local endpoints. Intended for local/dev servers only.
+   */
+  disableSsl?: boolean;
+}
+
 export interface MotherDuckConnection {
   readonly type: 'motherduck';
   id: PersistentDataSourceId;
@@ -351,6 +394,7 @@ export type AnyDataSource =
   | RemoteDB
   | IcebergCatalog
   | DuckLakeCatalog
+  | QuackConnection
   | MotherDuckConnection;
 
 // Special constant for the system database

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -9,6 +9,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
   PersistentDataSourceId,
 } from '@models/data-source';
@@ -436,6 +437,7 @@ export function useProtectedViews(): Set<string> {
                 dataSource.type !== 'remote-db' &&
                 dataSource.type !== 'iceberg-catalog' &&
                 dataSource.type !== 'ducklake-catalog' &&
+                dataSource.type !== 'quack' &&
                 dataSource.type !== 'motherduck',
             )
             .map((dataSource): string => (dataSource as AnyFlatFileDataSource).viewName),
@@ -460,6 +462,7 @@ export function useFlatFileDataSourceEMap(): Map<PersistentDataSourceId, AnyFlat
                 dataSource.type !== 'remote-db' &&
                 dataSource.type !== 'iceberg-catalog' &&
                 dataSource.type !== 'ducklake-catalog' &&
+                dataSource.type !== 'quack' &&
                 dataSource.type !== 'motherduck',
             ) as [PersistentDataSourceId, AnyFlatFileDataSource][],
         ),
@@ -480,6 +483,7 @@ export function useFlatFileDataSourceMap(): Map<PersistentDataSourceId, AnyFlatF
                 dataSource.type !== 'remote-db' &&
                 dataSource.type !== 'iceberg-catalog' &&
                 dataSource.type !== 'ducklake-catalog' &&
+                dataSource.type !== 'quack' &&
                 dataSource.type !== 'motherduck',
             ) as [PersistentDataSourceId, AnyFlatFileDataSource][],
         ),
@@ -505,24 +509,32 @@ export function useLocalDBDataSourceMap(): Map<PersistentDataSourceId, LocalDB> 
 
 export function useDatabaseDataSourceMap(): Map<
   PersistentDataSourceId,
-  LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | MotherDuckConnection
+  LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | QuackConnection | MotherDuckConnection
 > {
   return useAppStore(
     useShallow(
       (state) =>
         new Map(
           Array.from(state.dataSources.entries())
-            // Include local, remote, iceberg, ducklake catalog, and MotherDuck databases
+            // Include local, remote, iceberg, ducklake catalog, Quack, and MotherDuck databases
             .filter(
               ([, dataSource]) =>
                 dataSource.type === 'attached-db' ||
                 dataSource.type === 'remote-db' ||
                 dataSource.type === 'iceberg-catalog' ||
                 dataSource.type === 'ducklake-catalog' ||
+                dataSource.type === 'quack' ||
                 dataSource.type === 'motherduck',
             ) as [
             PersistentDataSourceId,
-            LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | MotherDuckConnection,
+            (
+              | LocalDB
+              | RemoteDB
+              | IcebergCatalog
+              | DuckLakeCatalog
+              | QuackConnection
+              | MotherDuckConnection
+            ),
           ][],
         ),
     ),

--- a/src/store/restore.ts
+++ b/src/store/restore.ts
@@ -100,7 +100,9 @@ async function getAppDataDBConnection(): Promise<IDBPDatabase<AppIdbSchema>> {
           const legacyDataSource = dv as { lastUsed?: number };
           const lastUsed =
             legacyDataSource.lastUsed ??
-            (dv.type === 'remote-db' ? dv.attachedAt : now - dataSourcesArray.length + index);
+            (dv.type === 'remote-db' || dv.type === 'quack'
+              ? dv.attachedAt
+              : now - dataSourcesArray.length + index);
           dataSourceAccessStore.put(lastUsed, dv.id);
         });
 
@@ -682,7 +684,9 @@ export const restoreAppDataFromIDB = async (
       const legacyDs = dv as LegacyDataSource;
       const lastUsed =
         legacyDs.lastUsed ??
-        (dv.type === 'remote-db' ? dv.attachedAt : now - dataSourcesArray.length + index);
+        (dv.type === 'remote-db' || dv.type === 'quack'
+          ? dv.attachedAt
+          : now - dataSourcesArray.length + index);
       dataSourceAccessTimes.set(dv.id, lastUsed);
     });
   }
@@ -954,6 +958,7 @@ export const restoreAppDataFromIDB = async (
       ds.type === 'remote-db' ||
       ds.type === 'iceberg-catalog' ||
       ds.type === 'ducklake-catalog' ||
+      ds.type === 'quack' ||
       ds.type === 'motherduck'
     ) {
       validDataSources.add(ds.id);

--- a/src/utils/attach-detach-handler.ts
+++ b/src/utils/attach-detach-handler.ts
@@ -262,11 +262,13 @@ export async function handleAttachStatements(
           Array.from(context.updatedDataSources.values()).find(
             (ds) =>
               (ds.type === 'remote-db' && ds.dbName === dbName) ||
+              (ds.type === 'quack' && ds.dbName === dbName) ||
               (ds.type === 'attached-db' && ds.dbName === dbName),
           ) ??
           Array.from(context.dataSources.values()).find(
             (ds) =>
               (ds.type === 'remote-db' && ds.dbName === dbName) ||
+              (ds.type === 'quack' && ds.dbName === dbName) ||
               (ds.type === 'attached-db' && ds.dbName === dbName),
           );
 
@@ -315,13 +317,14 @@ export async function handleDetachStatements(
     const dbToRemove = Array.from(context.updatedDataSources.entries()).find(
       ([, ds]) =>
         (ds.type === 'remote-db' && ds.dbName === dbName) ||
+        (ds.type === 'quack' && ds.dbName === dbName) ||
         (ds.type === 'attached-db' && ds.dbName === dbName) ||
         (ds.type === 'iceberg-catalog' && ds.catalogAlias === dbName) ||
         (ds.type === 'ducklake-catalog' && ds.catalogAlias === dbName),
     );
 
     if (dbToRemove) {
-      const [dbId, ds] = dbToRemove;
+      const [dbId] = dbToRemove;
       context.updatedDataSources.delete(dbId);
       context.updatedMetadata.delete(dbName);
 

--- a/src/utils/data-adapter.ts
+++ b/src/utils/data-adapter.ts
@@ -14,6 +14,7 @@ import {
   IcebergCatalog,
   LocalDB,
   MotherDuckConnection,
+  QuackConnection,
   RemoteDB,
   SYSTEM_DATABASE_ID,
   SYSTEM_DATABASE_NAME,
@@ -371,7 +372,13 @@ function getFlatFileDataAdapterQueries(
 // for database operations (both have dbName and dbType fields)
 function getDatabaseDataAdapterApi(
   pool: AsyncDuckDBConnectionPool,
-  dataSource: LocalDB | RemoteDB | IcebergCatalog | DuckLakeCatalog | MotherDuckConnection,
+  dataSource:
+    | LocalDB
+    | RemoteDB
+    | IcebergCatalog
+    | DuckLakeCatalog
+    | QuackConnection
+    | MotherDuckConnection,
   tab: TabReactiveState<LocalDBDataTab>,
   options: {
     usePagedReader?: boolean;
@@ -469,13 +476,15 @@ export function getFileDataAdapterQueries({
     return getDatabaseDataAdapterApi(pool, dataSource, tab);
   }
 
-  if (dataSource.type === 'remote-db') {
+  if (dataSource.type === 'remote-db' || dataSource.type === 'quack') {
+    const label = dataSource.type === 'quack' ? 'Quack server' : 'Remote database';
+
     if (tab.dataSourceType !== 'db') {
       return {
         adapter: null,
         userErrors: [],
         internalErrors: [
-          `Tried creating a remote db object data adapter from a tab with different source type: ${tab.dataSourceType}`,
+          `Tried creating a ${label} data adapter from a tab with different source type: ${tab.dataSourceType}`,
         ],
       };
     }
@@ -484,12 +493,12 @@ export function getFileDataAdapterQueries({
     if (dataSource.connectionState !== 'connected') {
       return {
         adapter: null,
-        userErrors: [`Remote database '${dataSource.dbName}' is not connected`],
+        userErrors: [`${label} '${dataSource.dbName}' is not connected`],
         internalErrors: [],
       };
     }
 
-    // Remote databases use the same logic as local databases
+    // Remote databases and Quack connections use the same logic as local databases
     return getDatabaseDataAdapterApi(pool, dataSource, tab);
   }
 

--- a/src/utils/data-source.ts
+++ b/src/utils/data-source.ts
@@ -6,6 +6,7 @@ import {
   LocalDB,
   MotherDuckConnection,
   PersistentDataSourceId,
+  QuackConnection,
   ReadStatView,
   RemoteDB,
 } from '@models/data-source';
@@ -40,6 +41,7 @@ export function ensureFlatFileDataSource(
     obj.type === 'remote-db' ||
     obj.type === 'iceberg-catalog' ||
     obj.type === 'ducklake-catalog' ||
+    obj.type === 'quack' ||
     obj.type === 'motherduck'
   ) {
     throw new Error(`Data source with id ${obj.id} is not a flat file data source`);
@@ -213,6 +215,10 @@ export function isDuckLakeCatalog(dataSource: AnyDataSource): dataSource is Duck
   return dataSource.type === 'ducklake-catalog';
 }
 
+export function isQuackConnection(dataSource: AnyDataSource): dataSource is QuackConnection {
+  return dataSource.type === 'quack';
+}
+
 export function isMotherDuckConnection(
   dataSource: AnyDataSource,
 ): dataSource is MotherDuckConnection {
@@ -252,6 +258,7 @@ export type DatabaseDataSource =
   | RemoteDB
   | IcebergCatalog
   | DuckLakeCatalog
+  | QuackConnection
   | MotherDuckConnection;
 
 export function isDatabaseDataSource(dataSource: AnyDataSource): dataSource is DatabaseDataSource {
@@ -260,14 +267,16 @@ export function isDatabaseDataSource(dataSource: AnyDataSource): dataSource is D
     dataSource.type === 'remote-db' ||
     dataSource.type === 'iceberg-catalog' ||
     dataSource.type === 'ducklake-catalog' ||
+    dataSource.type === 'quack' ||
     dataSource.type === 'motherduck'
   );
 }
 
 /**
  * Returns the DuckDB database name for a database data source.
- * For iceberg/ducklake catalogs this is the catalog alias; for others, the dbName.
- * MotherDuck connections don't have a single database name — returns the bare MD_DB_PREFIX.
+ * For Iceberg/DuckLake catalogs this is the catalog alias; for local, remote, and Quack
+ * sources this is the attached database name. MotherDuck connections don't have a single
+ * database name — returns the bare MD_DB_PREFIX.
  */
 export function getDatabaseIdentifier(dataSource: DatabaseDataSource): string {
   if (dataSource.type === 'iceberg-catalog') return dataSource.catalogAlias;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -6,6 +6,9 @@
 export function getViteEnv() {
   return {
     VITE_CORS_PROXY_URL: import.meta.env.VITE_CORS_PROXY_URL as string | undefined,
+    VITE_QUACK_WASM_EXTENSION_URL: import.meta.env.VITE_QUACK_WASM_EXTENSION_URL as
+      | string
+      | undefined,
     DEV: import.meta.env.DEV as boolean,
   };
 }

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -49,6 +49,7 @@ export function getTabName(
       dataSource.type !== 'remote-db' &&
       dataSource.type !== 'iceberg-catalog' &&
       dataSource.type !== 'ducklake-catalog' &&
+      dataSource.type !== 'quack' &&
       dataSource.type !== 'motherduck'
     ) {
       return 'Unknown data source';
@@ -67,6 +68,7 @@ export function getTabName(
     dataSource.type === 'remote-db' ||
     dataSource.type === 'iceberg-catalog' ||
     dataSource.type === 'ducklake-catalog' ||
+    dataSource.type === 'quack' ||
     dataSource.type === 'motherduck'
   ) {
     return 'Unknown data source';
@@ -102,6 +104,7 @@ export function getTabIcon(
       dataSource.type === 'remote-db' ||
       dataSource.type === 'iceberg-catalog' ||
       dataSource.type === 'ducklake-catalog' ||
+      dataSource.type === 'quack' ||
       dataSource.type === 'motherduck'
     ) {
       return 'error';

--- a/src/utils/quack.ts
+++ b/src/utils/quack.ts
@@ -1,0 +1,446 @@
+import { showError, showSuccess } from '@components/app-notifications';
+import { persistPutDataSources } from '@controllers/data-source/persist';
+import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
+import { PersistentDataSourceId, QuackConnection } from '@models/data-source';
+import { DataBaseModel, DBColumn, DBTableOrView } from '@models/db';
+import { AppIdbSchema } from '@models/persisted-store';
+import { getSecret } from '@services/secret-store';
+import { useAppStore } from '@store/app-store';
+import { makePersistentDataSourceId } from '@utils/data-source';
+import { getTableColumnId } from '@utils/db';
+import { toDuckDBIdentifier } from '@utils/duckdb/identifier';
+import { normalizeDuckDBColumnType } from '@utils/duckdb/sql-type';
+import { getViteEnv } from '@utils/env';
+import { sanitizeErrorMessage } from '@utils/sanitize-error';
+import { escapeSqlStringValue } from '@utils/sql-security';
+import * as arrow from 'apache-arrow';
+import { IDBPDatabase } from 'idb';
+
+export interface AttachQuackOptions {
+  pool: AsyncDuckDBConnectionPool;
+  uri: string;
+  dbName: string;
+  token: string;
+  disableSsl?: boolean;
+}
+
+export function validateQuackUri(uri: string): { isValid: boolean; error?: string } {
+  const trimmed = uri.trim();
+  if (!trimmed) return { isValid: false, error: 'Quack URI is required' };
+  if (/[;'"\\]/.test(trimmed)) {
+    return { isValid: false, error: 'URI contains unsupported characters' };
+  }
+  if (!/^quack:(?:\/\/)?[^/\s][^\s]*$/i.test(trimmed)) {
+    return { isValid: false, error: 'URI must start with quack: and include a host' };
+  }
+  return { isValid: true };
+}
+
+export function buildQuackSecretName(dbName: string): string {
+  return `pondpilot_quack_${dbName.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+}
+
+export function buildCreateQuackSecretQuery(
+  uri: string,
+  token: string,
+  secretName: string,
+): string {
+  return `CREATE OR REPLACE TEMPORARY SECRET ${toDuckDBIdentifier(secretName)} (TYPE quack, TOKEN '${escapeSqlStringValue(token)}', SCOPE '${escapeSqlStringValue(uri)}')`;
+}
+
+export function buildAttachQuackQuery(
+  uri: string,
+  dbName: string,
+  disableSsl = false,
+  token?: string,
+): string {
+  const options = [
+    ...(token ? [`TOKEN '${escapeSqlStringValue(token)}'`] : []),
+    ...(disableSsl ? ['DISABLE_SSL true'] : []),
+  ];
+  const optionsClause = options.length ? ` (${options.join(', ')})` : '';
+  return `ATTACH '${escapeSqlStringValue(uri)}' AS ${toDuckDBIdentifier(dbName)}${optionsClause}`;
+}
+
+const QUACK_QUERY_TIMEOUT_MS = 20_000;
+
+async function queryQuackWithTimeout<T>(query: Promise<T>, operation: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          `${operation} timed out after ${QUACK_QUERY_TIMEOUT_MS / 1000}s. ` +
+            'The current DuckDB-WASM bundle may not support Quack yet.',
+        ),
+      );
+    }, QUACK_QUERY_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([query, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+const getQuackWasmExtensionUrls = (): string[] => {
+  const configuredUrl = getViteEnv().VITE_QUACK_WASM_EXTENSION_URL;
+
+  return [
+    ...(configuredUrl ? [configuredUrl] : []),
+    // The official v1.5.2 artifact contains the full Quack extension symbols.
+    // It is kept as a direct-load fallback for newer DuckDB-WASM builds and as a
+    // storage-support retry when repository-loaded artifacts only expose helper
+    // functions without registering the Quack ATTACH storage type.
+    'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm',
+  ];
+};
+
+async function tryLoadQuackFromPinnedWasm(
+  pool: AsyncDuckDBConnectionPool,
+): Promise<{ loaded: true } | { loaded: false; error: string }> {
+  const errors: string[] = [];
+
+  for (const url of getQuackWasmExtensionUrls()) {
+    try {
+      await queryQuackWithTimeout(
+        pool.query(`LOAD '${url}'`),
+        'Loading the pinned Quack WASM extension',
+      );
+      return { loaded: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/already loaded/i.test(message)) {
+        return { loaded: true };
+      }
+      errors.push(`${url}: ${message}`);
+      console.warn('Failed to load pinned Quack WASM extension:', url, message);
+    }
+  }
+
+  return { loaded: false, error: errors.join('; ') };
+}
+
+const QUACK_EXTENSION_REPOSITORIES = [
+  'core_nightly',
+  'community',
+  "'https://community-extensions.duckdb.org'",
+];
+
+async function tryLoadQuackFromRepositories(
+  pool: AsyncDuckDBConnectionPool,
+): Promise<{ loaded: true } | { loaded: false; error: string }> {
+  const repositoryErrors: string[] = [];
+
+  for (const repository of QUACK_EXTENSION_REPOSITORIES) {
+    for (const installCommand of [
+      `FORCE INSTALL quack FROM ${repository}`,
+      `INSTALL quack FROM ${repository}`,
+    ]) {
+      try {
+        await queryQuackWithTimeout(
+          pool.query(installCommand),
+          `Installing the Quack extension from ${repository}`,
+        );
+        await queryQuackWithTimeout(pool.query('LOAD quack'), 'Loading the Quack extension');
+        return { loaded: true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (/already loaded/i.test(message)) {
+          return { loaded: true };
+        }
+        repositoryErrors.push(`${installCommand}: ${message}`);
+      }
+    }
+  }
+
+  return { loaded: false, error: repositoryErrors.join('; ') };
+}
+
+export async function loadQuackExtension(pool: AsyncDuckDBConnectionPool): Promise<void> {
+  const repositoryResult = await tryLoadQuackFromRepositories(pool);
+  if (repositoryResult.loaded) return;
+
+  const pinnedResult = await tryLoadQuackFromPinnedWasm(pool);
+  if (pinnedResult.loaded) {
+    try {
+      await queryQuackWithTimeout(pool.query('LOAD quack'), 'Loading the Quack extension');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !/already loaded|wasm magic number|could not be loaded|no extension found|failed to download/i.test(
+          message,
+        )
+      ) {
+        throw error;
+      }
+      console.warn('Failed to load Quack by name after pinned WASM load:', message);
+    }
+    return;
+  }
+
+  throw new Error(
+    'The current DuckDB-WASM bundle cannot load the Quack extension yet. ' +
+      'Upgrade DuckDB-WASM to a build that ships Quack support. ' +
+      `Repository errors: ${repositoryResult.error}. ` +
+      `Pinned WASM extension fallbacks failed: ${pinnedResult.error}`,
+  );
+}
+
+async function runAttachQuackQuery({
+  pool,
+  uri,
+  dbName,
+  token,
+  disableSsl,
+}: AttachQuackOptions): Promise<void> {
+  await queryQuackWithTimeout(
+    pool.query(buildAttachQuackQuery(uri, dbName, disableSsl, token)),
+    'Attaching the Quack connection',
+  );
+}
+
+export async function attachQuackConnection({
+  pool,
+  uri,
+  dbName,
+  token,
+  disableSsl,
+}: AttachQuackOptions): Promise<void> {
+  await loadQuackExtension(pool);
+  try {
+    await runAttachQuackQuery({ pool, uri, dbName, token, disableSsl });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/Unrecognized storage type\s+"?quack"?/i.test(message)) {
+      const pinnedResult = await tryLoadQuackFromPinnedWasm(pool);
+      if (pinnedResult.loaded) {
+        try {
+          await runAttachQuackQuery({ pool, uri, dbName, token, disableSsl });
+          return;
+        } catch (retryError) {
+          const retryMessage =
+            retryError instanceof Error ? retryError.message : String(retryError);
+          throw new Error(
+            'The current DuckDB-WASM bundle loaded Quack but does not register Quack ATTACH support yet. ' +
+              `Upgrade DuckDB-WASM to a build with Quack storage support. Original error: ${message}. ` +
+              `Pinned WASM retry failed: ${retryMessage}`,
+          );
+        }
+      }
+      throw new Error(
+        'The current DuckDB-WASM bundle loaded Quack but does not register Quack ATTACH support yet. ' +
+          `Upgrade DuckDB-WASM to a build with Quack storage support. Original error: ${message}. ` +
+          `Pinned WASM retry could not load Quack storage support: ${pinnedResult.error}`,
+      );
+    }
+    throw error;
+  }
+}
+
+export async function resolveQuackToken(
+  iDb: IDBPDatabase<AppIdbSchema>,
+  connection: QuackConnection,
+): Promise<string | null> {
+  if (!connection.secretRef) return null;
+  const secret = await getSecret(iDb, connection.secretRef);
+  return secret?.data?.token ?? null;
+}
+
+export function updateQuackConnectionState(
+  id: PersistentDataSourceId,
+  connectionState: QuackConnection['connectionState'],
+  connectionError?: string,
+): void {
+  const currentDataSources = useAppStore.getState().dataSources;
+  const dataSource = currentDataSources.get(id);
+
+  if (!dataSource || dataSource.type !== 'quack') return;
+
+  const newDataSources = new Map(currentDataSources);
+  newDataSources.set(id, { ...dataSource, connectionState, connectionError });
+  useAppStore.setState({ dataSources: newDataSources }, false, 'Quack/updateConnectionState');
+}
+
+type QuackColumnsQueryArrowType = {
+  is_table: arrow.Bool;
+  schema_name: arrow.Utf8;
+  table_name: arrow.Utf8;
+  column_name: arrow.Utf8;
+  column_index: arrow.Int32;
+  data_type: arrow.Utf8;
+  is_nullable: arrow.Bool;
+};
+
+export async function getQuackDatabaseModel(
+  pool: AsyncDuckDBConnectionPool,
+  dbName: string,
+): Promise<Map<string, DataBaseModel>> {
+  const remoteMetadataSql = `
+    SELECT
+      dt.table_oid IS NOT NULL AS is_table,
+      dc.schema_name,
+      dc.table_name,
+      dc.column_name,
+      dc.column_index,
+      dc.data_type,
+      dc.is_nullable
+    FROM duckdb_columns() AS dc
+    LEFT JOIN duckdb_tables() AS dt
+      ON dc.database_name = dt.database_name
+     AND dc.schema_name = dt.schema_name
+     AND dc.table_name = dt.table_name
+     AND dc.table_oid = dt.table_oid
+    WHERE NOT dc.internal
+      AND dc.database_name NOT IN ('system', 'temp')
+      AND dc.schema_name NOT IN ('information_schema', 'pg_catalog')
+    ORDER BY dc.schema_name, dc.table_name, dc.column_index
+  `;
+
+  const result = await pool.query<QuackColumnsQueryArrowType>(
+    `SELECT * FROM ${toDuckDBIdentifier(dbName)}.query('${escapeSqlStringValue(remoteMetadataSql)}')`,
+  );
+
+  const dbModel: DataBaseModel = { name: dbName, schemas: [] };
+  const columns = {
+    is_table: result.getChild('is_table'),
+    schema_name: result.getChild('schema_name'),
+    table_name: result.getChild('table_name'),
+    column_name: result.getChild('column_name'),
+    column_index: result.getChild('column_index'),
+    data_type: result.getChild('data_type'),
+    is_nullable: result.getChild('is_nullable'),
+  };
+
+  for (let i = 0; i < result.numRows; i += 1) {
+    const schemaName = columns.schema_name?.get(i);
+    const tableName = columns.table_name?.get(i);
+    const columnName = columns.column_name?.get(i);
+    const columnIndex = columns.column_index?.get(i);
+    const dataType = columns.data_type?.get(i);
+    const isNullable = columns.is_nullable?.get(i);
+    const isTable = columns.is_table?.get(i) ?? false;
+
+    if (
+      !schemaName ||
+      !tableName ||
+      !columnName ||
+      columnIndex === undefined ||
+      columnIndex === null ||
+      !dataType ||
+      isNullable === undefined ||
+      isNullable === null
+    ) {
+      continue;
+    }
+
+    let schema = dbModel.schemas.find((candidate) => candidate.name === schemaName);
+    if (!schema) {
+      schema = { name: schemaName, objects: [] };
+      dbModel.schemas.push(schema);
+    }
+
+    let tableOrView = schema.objects.find((candidate) => candidate.name === tableName);
+    if (!tableOrView) {
+      tableOrView = {
+        name: tableName,
+        label: tableName,
+        type: isTable ? 'table' : 'view',
+        columns: [],
+      } satisfies DBTableOrView;
+      schema.objects.push(tableOrView);
+    }
+
+    const column: DBColumn = {
+      name: columnName,
+      databaseType: dataType,
+      nullable: isNullable,
+      sqlType: normalizeDuckDBColumnType(dataType),
+      id: getTableColumnId(columnName, columnIndex),
+      columnIndex,
+    };
+    tableOrView.columns.push(column);
+  }
+
+  return new Map([[dbName, dbModel]]);
+}
+
+export async function refreshQuackMetadata(
+  pool: AsyncDuckDBConnectionPool,
+  connection: Pick<QuackConnection, 'dbName'>,
+): Promise<void> {
+  const metadata = await getQuackDatabaseModel(pool, connection.dbName);
+  const currentMetadata = useAppStore.getState().databaseMetadata;
+  const newMetadata = new Map(currentMetadata);
+  for (const [dbName, dbModel] of metadata) newMetadata.set(dbName, dbModel);
+  useAppStore.setState({ databaseMetadata: newMetadata }, false, 'Quack/loadMetadata');
+}
+
+export async function reconnectQuackConnection(
+  pool: AsyncDuckDBConnectionPool,
+  connection: QuackConnection,
+  token: string,
+): Promise<void> {
+  updateQuackConnectionState(connection.id, 'connecting');
+  try {
+    await attachQuackConnection({
+      pool,
+      uri: connection.uri,
+      dbName: connection.dbName,
+      token,
+      disableSsl: connection.disableSsl,
+    });
+
+    await refreshQuackMetadata(pool, connection);
+    updateQuackConnectionState(connection.id, 'connected');
+  } catch (error) {
+    const sanitized = sanitizeErrorMessage(error instanceof Error ? error.message : String(error));
+    updateQuackConnectionState(connection.id, 'error', sanitized);
+    throw error;
+  }
+}
+
+export async function disconnectQuackConnection(
+  pool: AsyncDuckDBConnectionPool,
+  connection: QuackConnection,
+): Promise<void> {
+  try {
+    await pool.query(`DETACH DATABASE IF EXISTS ${toDuckDBIdentifier(connection.dbName)}`);
+    const currentMetadata = useAppStore.getState().databaseMetadata;
+    const newMetadata = new Map(currentMetadata);
+    newMetadata.delete(connection.dbName);
+    useAppStore.setState({ databaseMetadata: newMetadata }, false, 'Quack/disconnect');
+    updateQuackConnectionState(connection.id, 'disconnected');
+    showSuccess({ title: 'Quack disconnected', message: `${connection.dbName} disconnected` });
+  } catch (error) {
+    const message = sanitizeErrorMessage(error instanceof Error ? error.message : String(error));
+    updateQuackConnectionState(connection.id, 'error', message);
+    showError({ title: 'Failed to disconnect Quack', message });
+  }
+}
+
+export function makeQuackConnection(params: {
+  uri: string;
+  dbName: string;
+  secretRef?: QuackConnection['secretRef'];
+  disableSsl?: boolean;
+  comment?: string;
+}): QuackConnection {
+  return {
+    type: 'quack',
+    id: makePersistentDataSourceId(),
+    uri: params.uri.trim(),
+    dbName: params.dbName.trim(),
+    connectionState: 'connecting',
+    attachedAt: Date.now(),
+    secretRef: params.secretRef,
+    disableSsl: params.disableSsl,
+    comment: params.comment,
+  };
+}
+
+export async function persistQuackConnection(connection: QuackConnection): Promise<void> {
+  const { _iDbConn } = useAppStore.getState();
+  if (_iDbConn) await persistPutDataSources(_iDbConn, [connection]);
+}

--- a/src/utils/tab-titles.ts
+++ b/src/utils/tab-titles.ts
@@ -37,6 +37,7 @@ export function getSchemaBrowserTabTitle(
       dataSource.type !== 'remote-db' &&
       dataSource.type !== 'iceberg-catalog' &&
       dataSource.type !== 'ducklake-catalog' &&
+      dataSource.type !== 'quack' &&
       dataSource.type !== 'motherduck'
     ) {
       return `File: ${(dataSource as AnyFlatFileDataSource).viewName}`;
@@ -46,6 +47,9 @@ export function getSchemaBrowserTabTitle(
 
   if (sourceType === 'db') {
     const dataSource = dataSources.get(sourceId as PersistentDataSourceId);
+    if (dataSource && dataSource.type === 'quack') {
+      return `Quack: ${dataSource.dbName}`;
+    }
     if (dataSource && dataSource.type === 'motherduck') {
       return tab.databaseName ? `Cloud: ${tab.databaseName}` : 'MotherDuck';
     }
@@ -146,6 +150,9 @@ export function getSchemaBrowserDisplayTitle(
 
   if (sourceType === 'db') {
     const dataSource = dataSources.get(sourceId as PersistentDataSourceId);
+    if (dataSource && dataSource.type === 'quack') {
+      return { prefix: 'Quack:', title: dataSource.dbName };
+    }
     if (dataSource && dataSource.type === 'motherduck') {
       const title = tab.databaseName ?? 'MotherDuck';
       return { prefix: 'Cloud:', title };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,33 @@
 interface ImportMetaEnv {
   /** URL for the Polly AI proxy (defaults to https://ai-proxy.pondpilot.io) */
   readonly VITE_POLLY_PROXY_URL?: string;
+
+  /** Optional CORS proxy URL for remote object-store requests. */
+  readonly VITE_CORS_PROXY_URL?: string;
+
+  /** Optional bug report proxy URL for Slack bug-report submissions. */
+  readonly VITE_BUG_REPORT_PROXY_URL?: string;
+
+  /** Optional DuckDB-WASM main module URL used to test newer compatible builds. */
+  readonly VITE_DUCKDB_WASM_MAIN_MODULE?: string;
+
+  /** Optional DuckDB-WASM main worker URL used to test newer compatible builds. */
+  readonly VITE_DUCKDB_WASM_MAIN_WORKER?: string;
+
+  /** Optional DuckDB-WASM pthread worker URL used to test newer compatible builds. */
+  readonly VITE_DUCKDB_WASM_PTHREAD_WORKER?: string;
+
+  /** Forces the MVP DuckDB-WASM bundle when set to "true". */
+  readonly VITE_DUCKDB_WASM_FORCE_MVP?: string;
+
+  /** Allows unsigned DuckDB-WASM extensions when set to "true". */
+  readonly VITE_DUCKDB_ALLOW_UNSIGNED_EXTENSIONS?: string;
+
+  /** Optional read_stat extension artifact URL used to test newer compatible builds. */
+  readonly VITE_READ_STAT_EXTENSION_URL?: string;
+
+  /** Optional Quack extension artifact URL used to test newer DuckDB-WASM-compatible builds. */
+  readonly VITE_QUACK_WASM_EXTENSION_URL?: string;
 }
 
 interface ImportMeta {

--- a/tests/integration/datasource-wizard/datasource-wizard.spec.ts
+++ b/tests/integration/datasource-wizard/datasource-wizard.spec.ts
@@ -25,8 +25,8 @@ test.describe('Datasource Wizard', () => {
     );
     await remoteDatabaseCard.click();
 
-    // Should show remote database config
-    await expect(page.getByText('Connect to a remote database using a URL')).toBeVisible();
+    // Should show remote server config
+    await expect(page.getByText('Files & URLs')).toBeVisible();
 
     // Click back button
     await page.getByTestId('back-to-selection').click();

--- a/tests/integration/datasource-wizard/quack-local-duckdb.spec.ts
+++ b/tests/integration/datasource-wizard/quack-local-duckdb.spec.ts
@@ -1,0 +1,50 @@
+import { execFileSync } from 'child_process';
+
+/* eslint-disable playwright/no-skipped-test -- Local Quack protocol smoke is gated because it downloads DuckDB CLI. */
+import { expect, test } from '@playwright/test';
+
+import {
+  DUCKDB_BINARY,
+  ensureDuckDBBinary,
+  getFreePort,
+  QUACK_E2E_TOKEN,
+  QuackServerProcess,
+  startQuackServer,
+  stopQuackServer,
+  waitForQuackServer,
+} from './quack-test-utils';
+
+test.describe('local DuckDB Quack protocol', () => {
+  test.skip(
+    process.env.RUN_QUACK_E2E !== 'true',
+    'Set RUN_QUACK_E2E=true to run the local DuckDB Quack protocol smoke test',
+  );
+
+  let server: QuackServerProcess | undefined;
+  let port: number;
+
+  test.beforeEach(async () => {
+    ensureDuckDBBinary();
+    port = await getFreePort();
+    server = startQuackServer(port);
+    await waitForQuackServer(port, server);
+  });
+
+  test.afterEach(async () => {
+    if (!server) return;
+    stopQuackServer(server);
+    server = undefined;
+  });
+
+  test('serves and queries data through Quack with DuckDB CLI v1.5.2', () => {
+    const sql = `
+INSTALL quack FROM core_nightly;
+LOAD quack;
+ATTACH 'quack:localhost:${port}' AS quack_remote (TOKEN '${QUACK_E2E_TOKEN}', DISABLE_SSL true);
+SELECT name FROM quack_remote.main.quack_items WHERE id = 2;
+`;
+
+    const output = execFileSync(DUCKDB_BINARY, ['-c', sql], { encoding: 'utf8' });
+    expect(output).toContain('beta');
+  });
+});

--- a/tests/integration/datasource-wizard/quack-test-utils.ts
+++ b/tests/integration/datasource-wizard/quack-test-utils.ts
@@ -1,0 +1,151 @@
+import { ChildProcessWithoutNullStreams, execFileSync, spawn } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync } from 'fs';
+import { createServer } from 'net';
+import { tmpdir } from 'os';
+import path from 'path';
+import { setTimeout as delay } from 'timers/promises';
+
+export const QUACK_E2E_TOKEN = 'pondpilot_test_token';
+
+const DUCKDB_CLI_VERSION = 'v1.5.2';
+const DUCKDB_CLI_URL = `https://github.com/duckdb/duckdb/releases/download/${DUCKDB_CLI_VERSION}/duckdb_cli-linux-amd64.zip`;
+
+export const DUCKDB_BINARY = process.env.DUCKDB_BINARY || path.resolve('.local-bin/duckdb');
+
+export async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate a local TCP port')));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForDuckDBInstall(lockDir: string, timeoutMs = 60_000): void {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!existsSync(lockDir) && existsSync(DUCKDB_BINARY)) return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  throw new Error(`Timed out waiting for DuckDB CLI installation lock: ${lockDir}`);
+}
+
+export function ensureDuckDBBinary(): void {
+  if (!existsSync(DUCKDB_BINARY)) {
+    if (process.env.DUCKDB_BINARY) {
+      throw new Error(`DUCKDB_BINARY does not exist: ${DUCKDB_BINARY}`);
+    }
+
+    const binDir = path.dirname(DUCKDB_BINARY);
+    const lockDir = path.join(binDir, 'duckdb-install.lock');
+
+    try {
+      mkdirSync(binDir, { recursive: true });
+      mkdirSync(lockDir);
+      try {
+        const zipPath = path.join(binDir, 'duckdb_cli-linux-amd64.zip');
+        execFileSync('curl', ['-fsSL', '-o', zipPath, DUCKDB_CLI_URL], { stdio: 'inherit' });
+        execFileSync('unzip', ['-o', zipPath, '-d', binDir], { stdio: 'inherit' });
+        execFileSync('chmod', ['+x', DUCKDB_BINARY]);
+        if (existsSync(zipPath)) unlinkSync(zipPath);
+      } finally {
+        rmSync(lockDir, { recursive: true, force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      waitForDuckDBInstall(lockDir);
+    }
+  }
+
+  execFileSync('chmod', ['+x', DUCKDB_BINARY]);
+  const version = execFileSync(DUCKDB_BINARY, ['--version'], { encoding: 'utf8' });
+  if (!version.includes(DUCKDB_CLI_VERSION)) {
+    throw new Error(`Expected DuckDB CLI ${DUCKDB_CLI_VERSION}, got: ${version.trim()}`);
+  }
+  process.stdout.write(version);
+}
+
+export interface QuackServerProcess {
+  proc: ChildProcessWithoutNullStreams;
+  dir: string;
+  stdout: string[];
+  stderr: string[];
+}
+
+export function startQuackServer(port: number): QuackServerProcess {
+  const dir = mkdtempSync(path.join(tmpdir(), 'pondpilot-quack-'));
+  const dbPath = path.join(dir, 'quack-server.duckdb');
+  const proc = spawn(DUCKDB_BINARY, [dbPath], { stdio: 'pipe' });
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  proc.stdout.on('data', (chunk) => stdout.push(String(chunk)));
+  proc.stderr.on('data', (chunk) => stderr.push(String(chunk)));
+
+  proc.stdin.write(`
+INSTALL quack FROM core_nightly;
+LOAD quack;
+CREATE TABLE IF NOT EXISTS quack_items(id INTEGER, name VARCHAR);
+DELETE FROM quack_items;
+INSERT INTO quack_items VALUES (1, 'alpha'), (2, 'beta');
+CALL quack_serve('quack:0.0.0.0:${port}', token='${QUACK_E2E_TOKEN}', allow_other_hostname=>true);
+`);
+
+  return { proc, dir, stdout, stderr };
+}
+
+export async function waitForQuackServer(
+  port: number,
+  server?: QuackServerProcess,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    if (server && server.proc.exitCode !== null) {
+      throw new Error(
+        `Local DuckDB Quack server exited with code ${server.proc.exitCode}. ` +
+          `stderr: ${server.stderr.join('').trim()}`,
+      );
+    }
+
+    try {
+      const output = execFileSync(
+        DUCKDB_BINARY,
+        [
+          '-c',
+          `INSTALL quack FROM core_nightly;
+LOAD quack;
+ATTACH 'quack:localhost:${port}' AS quack_remote (TOKEN '${QUACK_E2E_TOKEN}', DISABLE_SSL true);
+SELECT name FROM quack_remote.main.quack_items WHERE id = 2;`,
+        ],
+        { encoding: 'utf8' },
+      );
+      if (output.includes('beta')) return;
+      lastError = new Error(`Unexpected Quack readiness output: ${output}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(250);
+  }
+
+  const message = lastError instanceof Error ? lastError.message : String(lastError);
+  const stderr = server?.stderr.join('').trim();
+  const stderrMessage = stderr ? `. Server stderr: ${stderr}` : '';
+  throw new Error(
+    `Timed out waiting for local DuckDB Quack server on port ${port}: ${message}${stderrMessage}`,
+  );
+}
+
+export function stopQuackServer(server: QuackServerProcess): void {
+  server.proc.kill();
+  rmSync(server.dir, { recursive: true, force: true });
+}

--- a/tests/integration/datasource-wizard/quack.spec.ts
+++ b/tests/integration/datasource-wizard/quack.spec.ts
@@ -1,0 +1,114 @@
+/* eslint-disable playwright/no-skipped-test -- Quack browser E2E is gated until DuckDB-WASM ships compatible Quack support. */
+import { getNodeDataTestIdPrefix } from '@components/explorer-tree/utils/node-test-id';
+import { expect, mergeTests } from '@playwright/test';
+
+import {
+  ensureDuckDBBinary,
+  getFreePort,
+  QUACK_E2E_TOKEN,
+  QuackServerProcess,
+  startQuackServer,
+  stopQuackServer,
+  waitForQuackServer,
+} from './quack-test-utils';
+import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as notificationsTest } from '../fixtures/notifications';
+import { test as pageTest } from '../fixtures/page';
+import { test as scriptEditorTest } from '../fixtures/script-editor';
+import { test as scriptExplorerTest } from '../fixtures/script-explorer';
+import { test as spotlightTest } from '../fixtures/spotlight';
+
+const test = mergeTests(
+  pageTest,
+  spotlightTest,
+  notificationsTest,
+  fileSystemExplorerTest,
+  scriptExplorerTest,
+  scriptEditorTest,
+);
+
+test.describe('Quack datasource', () => {
+  test.setTimeout(90_000);
+
+  test.skip(
+    process.env.RUN_QUACK_E2E !== 'true',
+    'Set RUN_QUACK_E2E=true to run the Quack browser E2E against a local DuckDB server',
+  );
+
+  let server: QuackServerProcess | undefined;
+  let port: number;
+
+  test.beforeEach(async () => {
+    ensureDuckDBBinary();
+    port = await getFreePort();
+    server = startQuackServer(port);
+    await waitForQuackServer(port, server);
+  });
+
+  test.afterEach(async () => {
+    if (!server) return;
+    stopQuackServer(server);
+    server = undefined;
+  });
+
+  test('connects to a local DuckDB Quack server and queries data', async ({
+    page,
+    openDatasourceWizard,
+    waitForNotification,
+    createScriptAndSwitchToItsTab,
+    fillScript,
+    runScript,
+  }) => {
+    const browserDiagnostics: string[] = [];
+    page.on('console', (message) => {
+      if (!['warning', 'error'].includes(message.type())) return;
+      const text = message.text();
+      if (!/quack|duckdb|extension|wasm/i.test(text)) return;
+      browserDiagnostics.push(`[${message.type()}] ${text}`);
+    });
+
+    await openDatasourceWizard();
+    await page.getByRole('button', { name: /Remote Server/ }).click();
+    await page
+      .getByTestId('remote-server-kind-selector')
+      .getByText('Quack', { exact: true })
+      .click();
+
+    await page.getByTestId('quack-uri-input').fill(`quack:localhost:${port}`);
+    await page.getByTestId('quack-database-name-input').fill('quack_remote');
+    await page.getByTestId('quack-token-input').fill(QUACK_E2E_TOKEN);
+    await page.getByLabel('Disable SSL (local/dev only)').check();
+
+    await page.getByTestId('add-quack-button').click();
+    const notification = await waitForNotification(undefined, { timeout: 60000 });
+    const notificationText = await notification.innerText();
+    if (!notificationText.includes('Quack server added')) {
+      throw new Error(
+        `Expected notification to contain "Quack server added". Received:\n${notificationText}\n\n` +
+          `Browser diagnostics:\n${browserDiagnostics.join('\n') || '<none>'}`,
+      );
+    }
+
+    await expect(page.getByText('quack_remote ✓')).toBeVisible();
+
+    const remoteNodes = page.getByTestId(
+      new RegExp(`^${getNodeDataTestIdPrefix('data-explorer-remote', '.*')}-container$`),
+    );
+    const quackNode = remoteNodes.filter({
+      has: page.locator('p').getByText('quack_remote ✓', { exact: true }),
+    });
+    const quackNodeId = await quackNode.getAttribute('data-value');
+    if (!quackNodeId) throw new Error('Quack explorer node has no data-value');
+
+    await quackNode.click();
+    await page.locator(`div[data-value="${quackNodeId}.main"]`).click();
+    const quackItemsNode = page.locator(`div[data-value="${quackNodeId}.main.quack_items"]`);
+    await expect(quackItemsNode).toBeVisible();
+
+    await createScriptAndSwitchToItsTab();
+    await fillScript('SELECT name FROM quack_remote.main.quack_items WHERE id = 2;');
+    await runScript();
+
+    await expect(page.getByText('beta')).toBeVisible();
+  });
+});

--- a/tests/integration/fixtures/base.ts
+++ b/tests/integration/fixtures/base.ts
@@ -8,6 +8,12 @@ export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
     async ({ context }, use, testInfo) => {
       const isDebugMode = !!process.env.PLAYWRIGHT_DEBUG_TESTS;
+      const duckDbOverrideHosts = getHostsFromUrls([
+        process.env.VITE_DUCKDB_WASM_MAIN_MODULE,
+        process.env.VITE_DUCKDB_WASM_MAIN_WORKER,
+        process.env.VITE_DUCKDB_WASM_PTHREAD_WORKER,
+        process.env.VITE_QUACK_WASM_EXTENSION_URL,
+      ]);
 
       // Catch-all route to mock any other external requests
       await context.route(/^https?:\/\/(?!localhost|127\.0\.0\.1).*/, async (route) => {
@@ -23,6 +29,9 @@ export const test = base.extend<{ forEachTest: void }>({
         if (
           host === 'cdn.jsdelivr.net' ||
           host === 'extensions.duckdb.org' ||
+          host === 'community-extensions.duckdb.org' ||
+          host === 'nightly-extensions.duckdb.org' ||
+          duckDbOverrideHosts.has(host) ||
           host === 'cdn.sheetjs.com' ||
           host === 'fonts.gstatic.com' ||
           host === 'fonts.googleapis.com'
@@ -121,17 +130,22 @@ export const test = base.extend<{ forEachTest: void }>({
 
           // Extract the path from the URL
           const urlPath = url.pathname;
-          // Get the filename from the path
+          // Get the filename from the path for content-type inference, and use a URL-derived
+          // cache key so artifacts with the same basename from different DuckDB versions do not
+          // collide (for example v1.4.0 and v1.5.2 extension WASM files).
           const fileName = path.basename(urlPath);
+          const cacheFileName = encodeURIComponent(`${url.host}${url.pathname}`);
 
           // Check if the file exists in .module-cache
-          const staticFilePath = path.resolve(process.cwd(), '.module-cache', fileName);
+          const staticFilePath = path.resolve(process.cwd(), '.module-cache', cacheFileName);
 
           if (fs.existsSync(staticFilePath)) {
             // If the file exists locally, serve it and cache it in memory
             if (isDebugMode) {
               // eslint-disable-next-line no-console
-              console.debug(`📁 [${testInfo.title}] Serving cached file: ${fileName} from cache`);
+              console.debug(
+                `📁 [${testInfo.title}] Serving cached file: ${cacheFileName} from cache`,
+              );
             }
             const fileContent = await fs.promises.readFile(staticFilePath);
             // Determine content type based on file extension
@@ -169,7 +183,7 @@ export const test = base.extend<{ forEachTest: void }>({
               if (!fs.existsSync(cachePath)) {
                 fs.mkdirSync(cachePath, { recursive: true });
               }
-              await fs.promises.writeFile(path.join(cachePath, fileName), body);
+              await fs.promises.writeFile(path.join(cachePath, cacheFileName), body);
               if (isDebugMode) {
                 // eslint-disable-next-line no-console
                 console.debug(`✅ [${testInfo.title}] Successfully cached ${fileName}`);
@@ -223,6 +237,19 @@ function getContentTypeFromFileName(fileName: string): string {
     default:
       return 'application/octet-stream';
   }
+}
+
+function getHostsFromUrls(urls: Array<string | undefined>): Set<string> {
+  return new Set(
+    urls.flatMap((url) => {
+      if (!url) return [];
+      try {
+        return [new URL(url).host];
+      } catch {
+        return [];
+      }
+    }),
+  );
 }
 
 type RouteFulfillInput = Parameters<Route['fulfill']>[0];

--- a/tests/unit/__mocks__/env.ts
+++ b/tests/unit/__mocks__/env.ts
@@ -9,6 +9,7 @@ export function getViteEnv() {
     const { env } = (globalThis as any).import.meta;
     return {
       VITE_CORS_PROXY_URL: env.VITE_CORS_PROXY_URL as string | undefined,
+      VITE_QUACK_WASM_EXTENSION_URL: env.VITE_QUACK_WASM_EXTENSION_URL as string | undefined,
       DEV: env.DEV as boolean,
     };
   }
@@ -16,6 +17,7 @@ export function getViteEnv() {
   // Fallback for tests
   return {
     VITE_CORS_PROXY_URL: undefined,
+    VITE_QUACK_WASM_EXTENSION_URL: undefined,
     DEV: false,
   };
 }

--- a/tests/unit/jest-setup.js
+++ b/tests/unit/jest-setup.js
@@ -5,6 +5,7 @@ global.import = {
       DEV: false,
       PROD: true,
       VITE_CORS_PROXY_URL: undefined,
+      VITE_QUACK_WASM_EXTENSION_URL: undefined,
     },
   },
 };

--- a/tests/unit/store/restore-migration.test.ts
+++ b/tests/unit/store/restore-migration.test.ts
@@ -165,6 +165,31 @@ describe('LRU Migration Logic', () => {
       );
     });
 
+    it('should use attachedAt for Quack when lastUsed is missing', () => {
+      const attachedAt = mockNow - 50000;
+      const dataSourcesArray = [
+        { id: 'quack1', type: 'quack', dbName: 'quack_remote', uri: 'quack:localhost', attachedAt },
+        { id: 'local1', type: 'attached-db', dbName: 'local' },
+      ];
+
+      const dataSources = new Map(
+        dataSourcesArray.map((dv, index) => [
+          dv.id,
+          {
+            ...dv,
+            lastUsed:
+              (dv as any).lastUsed ??
+              (dv.type === 'remote-db' || dv.type === 'quack'
+                ? (dv as any).attachedAt
+                : mockNow - dataSourcesArray.length + index),
+          },
+        ]),
+      );
+
+      expect(dataSources.get('quack1')?.lastUsed).toBe(attachedAt);
+      expect(dataSources.get('local1')?.lastUsed).toBeDefined();
+    });
+
     it('should preserve existing lastUsed over attachedAt for RemoteDB', () => {
       const attachedAt = mockNow - 50000;
       const existingLastUsed = mockNow - 10000;

--- a/tests/unit/utils/attach-detach-handler.test.ts
+++ b/tests/unit/utils/attach-detach-handler.test.ts
@@ -134,6 +134,34 @@ describe('attach-detach-handler', () => {
       expect(mockPersistPut).toHaveBeenCalledTimes(1);
     });
 
+    it('should not create a remote-db duplicate for an existing Quack alias', async () => {
+      const quackId = 'existing-quack-id' as PersistentDataSourceId;
+      const existing = new Map<PersistentDataSourceId, AnyDataSource>([
+        [
+          quackId,
+          {
+            type: 'quack',
+            id: quackId,
+            uri: 'quack:localhost:9494',
+            dbName: 'remote_db',
+            disableSsl: true,
+            connectionState: 'connected',
+            attachedAt: 1000,
+          },
+        ],
+      ]);
+      const statements = [
+        makeStatement("ATTACH 'https://example.com/db.duckdb' AS remote_db", SQLStatement.ATTACH),
+      ];
+      const ctx = makeContext(existing);
+
+      await handleAttachStatements(statements, ctx);
+
+      expect(ctx.updatedDataSources.size).toBe(1);
+      expect(Array.from(ctx.updatedDataSources.values())[0]).toMatchObject({ type: 'quack' });
+      expect(mockPersistPut).not.toHaveBeenCalled();
+    });
+
     it('should not duplicate an Iceberg catalog with the same alias', async () => {
       const existingId = 'existing-ice-id' as PersistentDataSourceId;
       const existing = new Map<PersistentDataSourceId, AnyDataSource>([
@@ -558,6 +586,31 @@ describe('attach-detach-handler', () => {
         ],
       ]);
       const statements = [makeStatement('DETACH remote_db', SQLStatement.DETACH)];
+      const ctx = makeContext(existing);
+
+      await handleDetachStatements(statements, ctx);
+
+      expect(ctx.updatedDataSources.size).toBe(0);
+      expect(mockPersistDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove a quack data source by dbName', async () => {
+      const quackId = 'quack-id' as PersistentDataSourceId;
+      const existing = new Map<PersistentDataSourceId, AnyDataSource>([
+        [
+          quackId,
+          {
+            type: 'quack',
+            id: quackId,
+            uri: 'quack:localhost:9494',
+            dbName: 'quack_remote',
+            disableSsl: true,
+            connectionState: 'connected',
+            attachedAt: 1000,
+          },
+        ],
+      ]);
+      const statements = [makeStatement('DETACH quack_remote', SQLStatement.DETACH)];
       const ctx = makeContext(existing);
 
       await handleDetachStatements(statements, ctx);

--- a/tests/unit/utils/data-adapter.test.ts
+++ b/tests/unit/utils/data-adapter.test.ts
@@ -1,7 +1,7 @@
 import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
 import { describe, expect, it, jest } from '@jest/globals';
 import { DataAdapterStreamReader } from '@models/data-adapter';
-import { DuckLakeCatalog, PersistentDataSourceId } from '@models/data-source';
+import { DuckLakeCatalog, PersistentDataSourceId, QuackConnection } from '@models/data-source';
 import { LocalDBDataTab, TabReactiveState } from '@models/tab';
 import { getFileDataAdapterQueries } from '@utils/data-adapter';
 
@@ -133,5 +133,60 @@ describe('getFileDataAdapterQueries DuckLake reader', () => {
       expect.any(AbortSignal),
       true,
     );
+  });
+});
+
+describe('getFileDataAdapterQueries Quack connection state', () => {
+  it('reports a Quack-specific internal error when the tab source type is wrong', () => {
+    const quack: QuackConnection = {
+      type: 'quack',
+      id: 'quack-id' as PersistentDataSourceId,
+      uri: 'quack:localhost:9494',
+      dbName: 'quack_remote',
+      connectionState: 'connected',
+      attachedAt: Date.now(),
+    };
+
+    const result = getFileDataAdapterQueries({
+      pool: {} as AsyncDuckDBConnectionPool,
+      dataSource: quack,
+      tab: {
+        ...makeTab(),
+        dataSourceId: quack.id,
+        dataSourceType: 'file',
+      },
+      sourceFile: undefined,
+    });
+
+    expect(result.adapter).toBeNull();
+    expect(result.userErrors).toEqual([]);
+    expect(result.internalErrors).toEqual([
+      'Tried creating a Quack server data adapter from a tab with different source type: file',
+    ]);
+  });
+
+  it('reports a Quack-specific message when the connection is disconnected', () => {
+    const quack: QuackConnection = {
+      type: 'quack',
+      id: 'quack-id' as PersistentDataSourceId,
+      uri: 'quack:localhost:9494',
+      dbName: 'quack_remote',
+      connectionState: 'disconnected',
+      attachedAt: Date.now(),
+    };
+
+    const result = getFileDataAdapterQueries({
+      pool: {} as AsyncDuckDBConnectionPool,
+      dataSource: quack,
+      tab: {
+        ...makeTab(),
+        dataSourceId: quack.id,
+      },
+      sourceFile: undefined,
+    });
+
+    expect(result.adapter).toBeNull();
+    expect(result.userErrors).toEqual(["Quack server 'quack_remote' is not connected"]);
+    expect(result.internalErrors).toEqual([]);
   });
 });

--- a/tests/unit/utils/quack.test.ts
+++ b/tests/unit/utils/quack.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  attachQuackConnection,
+  buildAttachQuackQuery,
+  buildCreateQuackSecretQuery,
+  getQuackDatabaseModel,
+  loadQuackExtension,
+  validateQuackUri,
+} from '@utils/quack';
+
+jest.mock('@utils/duckdb/identifier', () => ({
+  toDuckDBIdentifier: jest.fn((str: string) => {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(str)) return str;
+    return `"${str.replace(/"/g, '""')}"`;
+  }),
+}));
+
+describe('quack utils', () => {
+  it('validates quack URIs', () => {
+    expect(validateQuackUri('quack:localhost:9494')).toEqual({ isValid: true });
+    expect(validateQuackUri('quack://localhost:9494')).toEqual({ isValid: true });
+    expect(validateQuackUri('quack://')).toEqual({
+      isValid: false,
+      error: 'URI must start with quack: and include a host',
+    });
+    expect(validateQuackUri("quack:localhost:9494'; DROP TABLE x; --")).toEqual({
+      isValid: false,
+      error: 'URI contains unsupported characters',
+    });
+    expect(validateQuackUri('https://example.com')).toEqual({
+      isValid: false,
+      error: 'URI must start with quack: and include a host',
+    });
+  });
+
+  it('builds a Quack ATTACH query with escaped alias, token, and SSL option', () => {
+    expect(buildAttachQuackQuery('quack:localhost:9494', 'my-quack', true, "tok'en")).toBe(
+      "ATTACH 'quack:localhost:9494' AS \"my-quack\" (TOKEN 'tok''en', DISABLE_SSL true)",
+    );
+  });
+
+  it('omits the Quack ATTACH options clause when no options are provided', () => {
+    expect(buildAttachQuackQuery('quack:localhost:9494', 'remote_quack')).toBe(
+      "ATTACH 'quack:localhost:9494' AS remote_quack",
+    );
+  });
+
+  it('builds a temporary Quack secret query and escapes token values', () => {
+    expect(buildCreateQuackSecretQuery('quack:localhost', "tok'en", 'quack_secret')).toBe(
+      "CREATE OR REPLACE TEMPORARY SECRET quack_secret (TYPE quack, TOKEN 'tok''en', SCOPE 'quack:localhost')",
+    );
+  });
+
+  it('loads Quack from core nightly first', async () => {
+    const query = jest.fn<() => Promise<unknown>>().mockResolvedValue({});
+
+    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+    expect(query).toHaveBeenNthCalledWith(1, 'FORCE INSTALL quack FROM core_nightly');
+    expect(query).toHaveBeenLastCalledWith('LOAD quack');
+  });
+
+  it('tries community repositories when core nightly fails', async () => {
+    const query = jest
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+    expect(query).toHaveBeenNthCalledWith(3, 'FORCE INSTALL quack FROM community');
+    expect(query).toHaveBeenLastCalledWith('LOAD quack');
+  });
+
+  it('falls back to pinned Quack WASM artifacts when repository loading fails', async () => {
+    const query = jest
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockRejectedValueOnce(new Error('community failed'))
+      .mockRejectedValueOnce(new Error('community failed'))
+      .mockRejectedValueOnce(new Error('explicit community failed'))
+      .mockRejectedValueOnce(new Error('explicit community failed'))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+    expect(query).toHaveBeenNthCalledWith(
+      7,
+      "LOAD 'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
+    );
+    expect(query).toHaveBeenLastCalledWith('LOAD quack');
+  });
+
+  it('honors a configured Quack WASM extension URL before pinned fallbacks', async () => {
+    const {
+      meta: { env },
+    } = (globalThis as any).import;
+    env.VITE_QUACK_WASM_EXTENSION_URL = '/duckdb-extensions/quack.duckdb_extension.wasm';
+    try {
+      const query = jest
+        .fn<() => Promise<unknown>>()
+        .mockRejectedValueOnce(new Error('core nightly failed'))
+        .mockRejectedValueOnce(new Error('core nightly failed'))
+        .mockRejectedValueOnce(new Error('community failed'))
+        .mockRejectedValueOnce(new Error('community failed'))
+        .mockRejectedValueOnce(new Error('explicit community failed'))
+        .mockRejectedValueOnce(new Error('explicit community failed'))
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+      expect(query).toHaveBeenNthCalledWith(
+        7,
+        "LOAD '/duckdb-extensions/quack.duckdb_extension.wasm'",
+      );
+      expect(query).toHaveBeenLastCalledWith('LOAD quack');
+    } finally {
+      env.VITE_QUACK_WASM_EXTENSION_URL = undefined;
+    }
+  });
+
+  it('retries with pinned Quack WASM artifacts when repository loading lacks ATTACH storage support', async () => {
+    const pool = {
+      query: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Binder Error: Unrecognized storage type "quack"'))
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({}),
+    };
+
+    await expect(
+      attachQuackConnection({
+        pool: pool as any,
+        uri: 'quack:localhost:9494',
+        dbName: 'remote_quack',
+        token: 'token',
+        disableSsl: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(pool.query).toHaveBeenNthCalledWith(
+      4,
+      "LOAD 'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
+    );
+  });
+
+  it('reports DuckDB-WASM bundles that load Quack without ATTACH storage support', async () => {
+    const pool = {
+      query: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Binder Error: Unrecognized storage type "quack"'))
+        .mockRejectedValueOnce(new Error('incompatible pinned artifact')),
+    };
+
+    await expect(
+      attachQuackConnection({
+        pool: pool as any,
+        uri: 'quack:localhost:9494',
+        dbName: 'remote_quack',
+        token: 'token',
+        disableSsl: true,
+      }),
+    ).rejects.toThrow('does not register Quack ATTACH support yet');
+  });
+
+  it('times out hanging Quack attach operations', async () => {
+    jest.useFakeTimers();
+    try {
+      const pool = {
+        query: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({})
+          .mockImplementationOnce(() => new Promise(() => {})),
+      };
+
+      const promise = attachQuackConnection({
+        pool: pool as any,
+        uri: 'quack:localhost:9494',
+        dbName: 'remote_quack',
+        token: 'token',
+        disableSsl: true,
+      });
+      const expectation = expect(promise).rejects.toThrow(
+        'Attaching the Quack connection timed out',
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(20_000);
+
+      await expectation;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('loads Quack sidebar metadata through the attached query macro', async () => {
+    const values: Record<string, unknown[]> = {
+      is_table: [true, true],
+      schema_name: ['main', 'main'],
+      table_name: ['quack_items', 'quack_items'],
+      column_name: ['id', 'name'],
+      column_index: [1, 2],
+      data_type: ['INTEGER', 'VARCHAR'],
+      is_nullable: [true, false],
+    };
+    const pool = {
+      query: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+        numRows: 2,
+        getChild: (name: string) => ({ get: (index: number) => values[name][index] }),
+      }),
+    };
+
+    const metadata = await getQuackDatabaseModel(pool as any, 'quack_remote');
+
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('quack_remote.query'));
+    expect(metadata.get('quack_remote')).toMatchObject({
+      name: 'quack_remote',
+      schemas: [
+        {
+          name: 'main',
+          objects: [
+            {
+              name: 'quack_items',
+              type: 'table',
+              columns: [
+                { name: 'id', databaseType: 'INTEGER', nullable: true },
+                { name: 'name', databaseType: 'VARCHAR', nullable: false },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('reports unsupported DuckDB-WASM bundles when Quack cannot load', async () => {
+    const pool = {
+      query: jest
+        .fn<() => Promise<unknown>>()
+        .mockRejectedValueOnce(new Error('incompatible extension'))
+        .mockRejectedValueOnce(new Error('core nightly failed'))
+        .mockRejectedValueOnce(new Error('core nightly failed'))
+        .mockRejectedValueOnce(new Error('community failed'))
+        .mockRejectedValueOnce(new Error('community failed'))
+        .mockRejectedValueOnce(new Error('explicit community failed'))
+        .mockRejectedValueOnce(new Error('explicit community failed')),
+    };
+
+    await expect(loadQuackExtension(pool as any)).rejects.toThrow(
+      'current DuckDB-WASM bundle cannot load the Quack extension yet',
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,13 +1552,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@duckdb/duckdb-wasm@npm:1.33.1-dev20.0":
-  version: 1.33.1-dev20.0
-  resolution: "@duckdb/duckdb-wasm@npm:1.33.1-dev20.0"
+"@duckdb/duckdb-wasm@npm:1.33.1-dev53.0":
+  version: 1.33.1-dev53.0
+  resolution: "@duckdb/duckdb-wasm@npm:1.33.1-dev53.0"
   dependencies:
     apache-arrow: "npm:^17.0.0"
     qs: "npm:^6.14.1"
-  checksum: 10c0/6c2ab133a4a5c58c985bc4ff6f99b403ebcb7e2fda387316c0aa5bc20fbdfa8bcb9f052fdd7a6b53040006fe71198755f54464422fe2cb02cd4edf5f13ffaa0d
+  checksum: 10c0/8db57249f3994293d5d44c045cf9888cc954d94d45cb04f8716dbf2367658c42c290b13e63c36178af4ca0d9d4507338d505b43f0a7555f254dea6cb04b5af84
   languageName: node
   linkType: hard
 
@@ -10179,7 +10179,7 @@ __metadata:
     "@dnd-kit/modifiers": "npm:^9.0.0"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
-    "@duckdb/duckdb-wasm": "npm:1.33.1-dev20.0"
+    "@duckdb/duckdb-wasm": "npm:1.33.1-dev53.0"
     "@hello-pangea/dnd": "npm:^17.0.0"
     "@mantine/core": "npm:^8.2.3"
     "@mantine/hooks": "npm:^8.2.3"


### PR DESCRIPTION
## Summary
- add Quack Server as a first-class data source with encrypted token storage
- attach/reconnect Quack databases, load remote schema metadata, and integrate with explorer/tabs/comparison flows
- update DuckDB-WASM handling for Quack extension loading and add gated browser/local DuckDB E2E coverage

## Validation
- yarn test:unit --runInBand
- yarn typecheck
- yarn lint:eslint --quiet
- yarn lint:stylelint
- yarn prettier --cache false "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}"
- RUN_QUACK_E2E=true VITE_DUCKDB_ALLOW_UNSIGNED_EXTENSIONS=true yarn build:test
- RUN_QUACK_E2E=true VITE_DUCKDB_ALLOW_UNSIGNED_EXTENSIONS=true yarn test:no-build tests/integration/datasource-wizard/quack*.spec.ts --project=chromium
- yarn test:no-build tests/integration/datasource-wizard/quack*.spec.ts --project=chromium
- git diff --check