### PR TITLE
fix(release): coerce dry_run string to boolean in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,8 @@ jobs:
         with:
           script: |
             const releaseId = parseInt("${{ steps.get_draft.outputs.release_id }}", 10);
-            const dryRun = context.payload.inputs.dry_run;
+            // workflow_dispatch boolean inputs arrive as strings — coerce explicitly so "false" doesn't read as truthy
+            const dryRun = context.payload.inputs.dry_run === 'true';
             const version = context.payload.inputs.version;
 
             if (dryRun) {


### PR DESCRIPTION
## Summary

- `workflow_dispatch` boolean inputs come through as **strings** inside `actions/github-script` (`context.payload.inputs.dry_run` is `"true"` or `"false"`)
- `"false"` is a truthy JS string, so the existing `if (dryRun) { return; }` guard in the "Publish the draft release" step fires regardless of which option the user picks
- Fix: coerce explicitly with `=== 'true'`

## Impact before this fix

- `release.yml` runs the "Commit changes" step correctly (bash compares strings explicitly), so `CHANGELOG.md` and `package.json` get committed to `main`
- But "Publish the draft release" always returns early — the draft is never published and the tag is never created
- Operator has to manually publish the draft (`gh release edit vX.Y.Z --draft=false`) every release
- v0.9.0 release surfaced this; v0.8.0 was also published manually

## Test plan

- [ ] Next release: run `release.yml` with `dry_run=false` and confirm the draft auto-publishes (tag created, release transitions out of draft state)
- [ ] Verify `dry_run=true` still short-circuits and prints the "Dry run for version …" message without touching the draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)