### PR TITLE
fix(theme): resolve auto color scheme to correct theme on first render

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -28,7 +28,7 @@ export default function App() {
   });
 
   return (
-    <MantineProvider theme={theme}>
+    <MantineProvider theme={theme} defaultColorScheme="auto">
       <ModalsProvider>
         <ModifierProvider>
           <TabCoordinationProvider>

--- a/src/hooks/use-app-theme.ts
+++ b/src/hooks/use-app-theme.ts
@@ -1,9 +1,13 @@
-import { useMantineColorScheme } from '@mantine/core';
-import { useColorScheme } from '@mantine/hooks';
+import { useComputedColorScheme } from '@mantine/core';
 
-export const useAppTheme = () => {
-  const { colorScheme } = useMantineColorScheme();
-  const systemColorScheme = useColorScheme();
-
-  return colorScheme === 'auto' ? systemColorScheme : colorScheme;
-};
+/**
+ * Resolved app color scheme ('light' | 'dark').
+ *
+ * Uses Mantine's computed color scheme, which resolves the 'auto' setting to the
+ * actual applied scheme in sync with `data-mantine-color-scheme`. `getInitialValueInEffect: false`
+ * makes it read the real value on the first render (instead of defaulting to light and
+ * correcting in an effect), so consumers like the Monaco editor get the correct theme at
+ * mount and never flash/stick to the light theme while the app is dark.
+ */
+export const useAppTheme = () =>
+  useComputedColorScheme('light', { getInitialValueInEffect: false });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { ColorSchemeScript } from '@mantine/core';
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
@@ -5,6 +6,7 @@ import App from './app';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <StrictMode>
+    <ColorSchemeScript defaultColorScheme="auto" />
     <App />
   </StrictMode>,
 );


### PR DESCRIPTION
## Problem

When the color scheme is set to `auto`, the app could mount with the **light** theme even though the system/applied scheme was **dark**. This caused a flash of light theme on load, and in some cases a sticky mismatch (most visible in the Monaco editor, which read the theme only at mount).

Root cause: `useAppTheme` relied on `useMantineColorScheme` + `useColorScheme`, resolving `auto` after mount in an effect, so the first render defaulted to light and corrected a tick later.

## Changes

- **`src/app.tsx`** — set `defaultColorScheme="auto"` on `MantineProvider`.
- **`src/main.tsx`** — add `<ColorSchemeScript defaultColorScheme="auto" />` so the applied scheme is established before first paint.
- **`src/hooks/use-app-theme.ts`** — rework `useAppTheme` to use `useComputedColorScheme('light', { getInitialValueInEffect: false })`, so it reads the real resolved scheme on the initial render instead of defaulting to light and correcting in an effect.

## Result

Consumers like the Monaco editor get the correct theme at mount — no flash, no light-theme stick while the app is dark.