### PR TITLE
fix(duckdb): work around OPFS data loss on reload (upstream #2192)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -15,6 +15,12 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Cross-origin isolation: required for SharedArrayBuffer (MotherDuck
+    # extension, multithreaded DuckDB-WASM). Matches public/_headers and the
+    # Vite dev server configuration.
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Embedder-Policy "credentialless" always;
+
     # Serve static files directly
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/src/features/duckdb-context/duckdb-bundles.ts
+++ b/src/features/duckdb-context/duckdb-bundles.ts
@@ -1,0 +1,152 @@
+/**
+ * DuckDB-WASM bundle resolution.
+ *
+ * `duckdb.getJsDelivrBundles()` only returns the single-threaded MVP and EH
+ * builds — upstream intentionally excludes the multithreaded COI build while
+ * it is experimental ("let the user opt in explicitly"). The app is served
+ * cross-origin isolated (Cross-Origin-Opener-Policy: same-origin /
+ * Cross-Origin-Embedder-Policy: credentialless), so when the COI bundle is
+ * offered, `duckdb.selectBundle` picks it whenever the browser reports
+ * `crossOriginIsolated` and supports WASM threads, exceptions and SIMD, and
+ * falls back to EH (then MVP) otherwise — e.g. Safari, which does not support
+ * COEP: credentialless and therefore never cross-origin isolates the app.
+ *
+ * The COI bundle is opt-in (`VITE_DUCKDB_WASM_ENABLE_COI=true`) because the
+ * extension ecosystem cannot load under it yet: every dynamic extension on
+ * extensions.duckdb.org is published as a `wasm_threads` artifact built
+ * against non-shared memory, which fails WebAssembly linking against the
+ * shared-memory COI module ("mismatch in shared state of memory", upstream
+ * issue duckdb/duckdb-wasm#1916), and MotherDuck ships no wasm_threads build
+ * at all. The engine itself works multithreaded (verified: 4–16 threads,
+ * ~4x speedup on aggregation). Flip the default once upstream publishes
+ * linkable wasm_threads extension artifacts; the runtime COI→EH fallback in
+ * duckdb-context keeps an enabled COI safe in the meantime.
+ *
+ * This module is deliberately free of runtime imports from
+ * `@duckdb/duckdb-wasm` (type-only imports are erased) so the resolution
+ * logic stays unit-testable in Node.
+ */
+import type { DuckDBBundle, DuckDBBundles } from '@duckdb/duckdb-wasm';
+
+/** Env-driven overrides for bundle resolution (see `src/vite-env.d.ts`). */
+export interface DuckDBBundleOverrides {
+  /** Optional DuckDB-WASM main module URL used to test newer compatible builds. */
+  mainModule?: string;
+  /** Optional DuckDB-WASM main worker URL used to test newer compatible builds. */
+  mainWorker?: string;
+  /** Optional DuckDB-WASM pthread worker URL used to test newer compatible builds. */
+  pthreadWorker?: string;
+  /** Forces the MVP bundle (disables EH and COI). */
+  forceMvp?: boolean;
+  /** Offers the multithreaded COI bundle for selection. */
+  enableCoi?: boolean;
+}
+
+const MVP_MAIN_MODULE_FILENAME = 'duckdb-mvp.wasm';
+
+/**
+ * Derives the COI bundle URLs from the MVP main module URL.
+ *
+ * All bundle artifacts live side by side in the package `dist/` directory, so
+ * deriving from the URL jsDelivr already pins to the installed package version
+ * keeps the COI build in lockstep with the EH/MVP builds across upgrades.
+ *
+ * Returns undefined when the URL does not look like a standard dist layout
+ * (in which case COI is simply not offered and selection proceeds as before).
+ */
+export function deriveCoiBundle(mvpMainModuleUrl: string): DuckDBBundles['coi'] | undefined {
+  const lastSlash = mvpMainModuleUrl.lastIndexOf('/');
+  if (lastSlash === -1) return undefined;
+  if (mvpMainModuleUrl.slice(lastSlash + 1) !== MVP_MAIN_MODULE_FILENAME) return undefined;
+
+  const base = mvpMainModuleUrl.slice(0, lastSlash + 1);
+  return {
+    mainModule: `${base}duckdb-coi.wasm`,
+    mainWorker: `${base}duckdb-browser-coi.worker.js`,
+    pthreadWorker: `${base}duckdb-browser-coi.pthread.worker.js`,
+  };
+}
+
+/**
+ * Builds the bundle map handed to `duckdb.selectBundle`.
+ *
+ * Without overrides this is the default jsDelivr map extended with a derived
+ * COI entry (unless `disableCoi`). With overrides it preserves the historical
+ * behavior exactly: explicit artifact URLs replace the EH/MVP entries and COI
+ * is not offered, since override URLs target one specific build.
+ */
+export function resolveDuckDBBundles(
+  defaultBundles: DuckDBBundles,
+  overrides: DuckDBBundleOverrides = {},
+): DuckDBBundles {
+  const { mainModule, mainWorker, pthreadWorker, forceMvp, enableCoi } = overrides;
+
+  if (mainModule || mainWorker || pthreadWorker || forceMvp) {
+    const ehModuleFallback = !mainModule && !defaultBundles.eh?.mainModule;
+    const ehWorkerFallback = !mainWorker && !defaultBundles.eh?.mainWorker;
+    if (!forceMvp && (ehModuleFallback || ehWorkerFallback)) {
+      console.warn(
+        'DuckDB-WASM exception-handling (EH) bundle unavailable; falling back to MVP build. ' +
+          'EH-only features will be disabled.',
+      );
+    }
+    const overriddenBundles: DuckDBBundles = {
+      mvp: {
+        mainModule: mainModule || defaultBundles.mvp.mainModule,
+        mainWorker: mainWorker || defaultBundles.mvp.mainWorker,
+      },
+      ...(forceMvp
+        ? {}
+        : {
+            eh: {
+              mainModule:
+                mainModule || defaultBundles.eh?.mainModule || defaultBundles.mvp.mainModule,
+              mainWorker:
+                mainWorker || defaultBundles.eh?.mainWorker || defaultBundles.mvp.mainWorker,
+              ...(pthreadWorker ? { pthreadWorker } : {}),
+            },
+          }),
+    };
+    return overriddenBundles;
+  }
+
+  if (!enableCoi) {
+    return defaultBundles;
+  }
+
+  const coi = deriveCoiBundle(defaultBundles.mvp.mainModule);
+  return coi ? { ...defaultBundles, coi } : defaultBundles;
+}
+
+/**
+ * Returns true when `selectBundle` picked the multithreaded COI bundle.
+ * Used to decide whether a failed initialization may retry single-threaded.
+ */
+export function isCoiBundleSelection(bundle: DuckDBBundle, bundles: DuckDBBundles): boolean {
+  return bundles.coi != null && bundle.mainModule === bundles.coi.mainModule;
+}
+
+/**
+ * Returns the bundle map with the COI entry removed, for the single-threaded
+ * retry after a failed COI initialization.
+ */
+export function withoutCoiBundle(bundles: DuckDBBundles): DuckDBBundles {
+  return {
+    mvp: bundles.mvp,
+    ...(bundles.eh ? { eh: bundles.eh } : {}),
+  };
+}
+
+/**
+ * Thread count passed as `maximumThreads` when opening a COI (multithreaded)
+ * database. DuckDB-WASM defaults to 4 threads regardless of cores; measured
+ * speedups on aggregation plateau past 8 threads while every pthread costs
+ * stack and operator memory inside the 4GB wasm32 address space, so cap at 8
+ * and always leave one core for the main thread and UI.
+ */
+export function recommendedThreadCount(hardwareConcurrency: number): number {
+  if (!Number.isFinite(hardwareConcurrency) || hardwareConcurrency < 2) {
+    return 2;
+  }
+  return Math.max(2, Math.min(hardwareConcurrency - 1, 8));
+}

--- a/src/features/duckdb-context/duckdb-connection-pool.ts
+++ b/src/features/duckdb-context/duckdb-connection-pool.ts
@@ -32,6 +32,12 @@ export interface CheckpointConfig {
   checkpointOnClose: boolean;
   // Whether to log checkpoint operations (in development mode)
   logCheckpoints: boolean;
+  // Database to checkpoint. A bare `FORCE CHECKPOINT;` only checkpoints the
+  // claimed connection's CURRENT database — pooled connections can sit on a
+  // different catalog (e.g. the MotherDuck flows reset their connections to
+  // `USE memory`), silently turning the checkpoint into a no-op for the
+  // persistent database. Always name the target explicitly when persisting.
+  checkpointDatabase?: string;
 }
 
 // Default checkpoint configuration
@@ -163,6 +169,62 @@ export class AsyncDuckDBConnectionPool {
   private _lastCheckpointTime: number = 0;
   private _changesSinceLastCheckpoint: number = 0;
   private _checkpointInProgress: boolean = false;
+  private _checkpointTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Schedules a deferred checkpoint for pending changes.
+   *
+   * Checkpoints normally run when a connection is released, but a write can
+   * be the last release of a session — the user then only browses on pinned
+   * connections or goes idle, so no further release ever crosses the
+   * throttle boundary. DuckDB-WASM does not replay the OPFS WAL on the next
+   * load, so changes that never reach a checkpoint are lost on reload. One
+   * coalesced timer guarantees an upper bound of ~throttleMs between any
+   * write and its checkpoint regardless of connection activity.
+   */
+  private _scheduleCheckpoint(delayMs: number): void {
+    if (this._checkpointTimer != null) {
+      return;
+    }
+    this._checkpointTimer = setTimeout(
+      () => {
+        this._checkpointTimer = null;
+        if (this._changesSinceLastCheckpoint <= 0) {
+          return;
+        }
+        this.forceCheckpoint().then((succeeded) => {
+          // A failed checkpoint (e.g. transient contention) keeps its pending
+          // changes — retry after another throttle interval.
+          if (!succeeded && this._changesSinceLastCheckpoint > 0) {
+            this._scheduleCheckpoint(this._checkpointConfig.throttleMs);
+          }
+        });
+      },
+      Math.max(delayMs, 0),
+    );
+  }
+
+  /**
+   * The checkpoint statement, targeting the configured database explicitly
+   * when one is set (see CheckpointConfig.checkpointDatabase).
+   */
+  private _checkpointStatement(): string {
+    const target = this._checkpointConfig.checkpointDatabase;
+    return target ? `FORCE CHECKPOINT ${toDuckDBIdentifier(target)};` : 'FORCE CHECKPOINT;';
+  }
+
+  /**
+   * Checkpoints immediately if any changes are pending.
+   *
+   * Used by page lifecycle hooks (visibility change / page hide) to shrink
+   * the window of WAL-only data before a reload or tab close.
+   */
+  public async flushPendingChanges(): Promise<boolean> {
+    if (this._changesSinceLastCheckpoint <= 0) {
+      return true;
+    }
+    return this.forceCheckpoint();
+  }
 
   private async _ensureConnectionInitialized(conn: AsyncDuckDBConnection): Promise<void> {
     if (!this._connectionInitializer) {
@@ -829,8 +891,12 @@ export class AsyncDuckDBConnectionPool {
     try {
       const conn = this._connections[index];
 
-      // If we're in persistent mode, handle potential checkpointing
-      if (this._updateStateCallback) {
+      // If we're in persistent mode, handle potential checkpointing.
+      // Releases made by a running checkpoint itself (forceCheckpoint
+      // releases its own connection) must not count as new changes — that
+      // would re-arm the deferred checkpoint timer after every checkpoint
+      // and run them in an endless loop.
+      if (this._updateStateCallback && !this._checkpointInProgress) {
         // Increment the changes counter
         this._changesSinceLastCheckpoint += 1;
 
@@ -861,7 +927,7 @@ export class AsyncDuckDBConnectionPool {
 
             // Create a checkpoint to ensure data is saved to disk
             // Use FORCE CHECKPOINT to wait for other transactions
-            await conn.query('FORCE CHECKPOINT;');
+            await conn.query(this._checkpointStatement());
 
             // Update persistence state
             await this._updateStateCallback();
@@ -873,11 +939,19 @@ export class AsyncDuckDBConnectionPool {
             console.error('Error during checkpoint or persistence state update:', error);
 
             // We don't rethrow the error to ensure the connection is always released,
-            // but at least the error is logged for debugging purposes
+            // but at least the error is logged for debugging purposes.
+            // The changes are still pending — make sure a retry happens even
+            // if no further connection release ever occurs.
+            this._scheduleCheckpoint(this._checkpointConfig.throttleMs);
           } finally {
             // Always mark checkpoint as no longer in progress
             this._checkpointInProgress = false;
           }
+        } else if (this._changesSinceLastCheckpoint > 0) {
+          // Throttled (or a checkpoint is already running): guarantee these
+          // changes still reach a checkpoint even if this was the session's
+          // last connection release.
+          this._scheduleCheckpoint(this._checkpointConfig.throttleMs - timeSinceLastCheckpoint);
         }
       }
     } catch (error) {
@@ -928,7 +1002,7 @@ export class AsyncDuckDBConnectionPool {
       try {
         // Create a checkpoint
         // Use FORCE CHECKPOINT to wait for other transactions
-        await conn.query('FORCE CHECKPOINT;');
+        await conn.query(this._checkpointStatement());
 
         // Update persistence state
         await this._updateStateCallback();
@@ -960,6 +1034,11 @@ export class AsyncDuckDBConnectionPool {
    * Performs a final checkpoint if configured to do so and there are pending changes.
    */
   public async close() {
+    if (this._checkpointTimer != null) {
+      clearTimeout(this._checkpointTimer);
+      this._checkpointTimer = null;
+    }
+
     for (const tabId of Array.from(this._pinnedTabs.keys())) {
       try {
         await this.unpinTab(tabId);

--- a/src/features/duckdb-context/duckdb-context.tsx
+++ b/src/features/duckdb-context/duckdb-context.tsx
@@ -15,7 +15,14 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState } f
 import { v4 } from 'uuid';
 
 import { setCurrentDuckDBConnectionPool } from './current-pool';
+import {
+  isCoiBundleSelection,
+  recommendedThreadCount,
+  resolveDuckDBBundles,
+  withoutCoiBundle,
+} from './duckdb-bundles';
 import { AsyncDuckDBConnectionPool } from './duckdb-connection-pool';
+import { isWalReplayFailure, planOpfsDatabaseRegistration } from './opfs-database-files';
 import { buildDuckDBWorkerBootstrap } from './worker-log-filter';
 
 class DuckDBInitializationCancelledError extends Error {
@@ -99,46 +106,17 @@ export const DuckDBConnectionPoolProvider = ({
   // Get persistence state from context
   const { persistenceState, updatePersistenceState } = useDuckDBPersistence();
 
-  // Use static cdn hosted bundles by default. Allow tests/preview builds to
-  // point at newer DuckDB-WASM artifacts before an npm package is published.
-  const JSDELIVR_BUNDLES = (() => {
-    const defaultBundles = duckdb.getJsDelivrBundles();
-    const mainModule = import.meta.env.VITE_DUCKDB_WASM_MAIN_MODULE;
-    const mainWorker = import.meta.env.VITE_DUCKDB_WASM_MAIN_WORKER;
-    const pthreadWorker = import.meta.env.VITE_DUCKDB_WASM_PTHREAD_WORKER;
-    const forceMvp = import.meta.env.VITE_DUCKDB_WASM_FORCE_MVP === 'true';
-
-    if (mainModule || mainWorker || pthreadWorker || forceMvp) {
-      const ehModuleFallback = !mainModule && !defaultBundles.eh?.mainModule;
-      const ehWorkerFallback = !mainWorker && !defaultBundles.eh?.mainWorker;
-      if (!forceMvp && (ehModuleFallback || ehWorkerFallback)) {
-        console.warn(
-          'DuckDB-WASM exception-handling (EH) bundle unavailable; falling back to MVP build. ' +
-            'EH-only features will be disabled.',
-        );
-      }
-      const overriddenBundles: duckdb.DuckDBBundles = {
-        mvp: {
-          mainModule: mainModule || defaultBundles.mvp.mainModule,
-          mainWorker: mainWorker || defaultBundles.mvp.mainWorker,
-        },
-        ...(forceMvp
-          ? {}
-          : {
-              eh: {
-                mainModule:
-                  mainModule || defaultBundles.eh?.mainModule || defaultBundles.mvp.mainModule,
-                mainWorker:
-                  mainWorker || defaultBundles.eh?.mainWorker || defaultBundles.mvp.mainWorker,
-                ...(pthreadWorker ? { pthreadWorker } : {}),
-              },
-            }),
-      };
-      return overriddenBundles;
-    }
-
-    return defaultBundles;
-  })();
+  // Use static cdn hosted bundles by default, optionally extended with the
+  // multithreaded COI bundle (opt-in; see duckdb-bundles.ts for why). Allow
+  // tests/preview builds to point at newer DuckDB-WASM artifacts before an
+  // npm package is published.
+  const JSDELIVR_BUNDLES = resolveDuckDBBundles(duckdb.getJsDelivrBundles(), {
+    mainModule: import.meta.env.VITE_DUCKDB_WASM_MAIN_MODULE,
+    mainWorker: import.meta.env.VITE_DUCKDB_WASM_MAIN_WORKER,
+    pthreadWorker: import.meta.env.VITE_DUCKDB_WASM_PTHREAD_WORKER,
+    forceMvp: import.meta.env.VITE_DUCKDB_WASM_FORCE_MVP === 'true',
+    enableCoi: import.meta.env.VITE_DUCKDB_WASM_ENABLE_COI === 'true',
+  });
 
   // create a logger
   //
@@ -151,9 +129,12 @@ export const DuckDBConnectionPoolProvider = ({
     logQueries ? duckdb.LogLevel.INFO : duckdb.LogLevel.WARNING,
   );
 
-  // duckdb worker and blob URL references
+  // duckdb worker and blob URL references. The pthread worker blob (COI
+  // bundle only) must stay alive for the lifetime of the database: Emscripten
+  // spawns pthread workers lazily, long after instantiation.
   const worker = useRef<Worker | null>(null);
   const workerBlobUrl = useRef<string | null>(null);
+  const pthreadWorkerBlobUrl = useRef<string | null>(null);
   const cancelTokenRef = useRef(0);
   const isCleaningUpRef = useRef(false);
   const ALLOW_UNSIGNED_EXTENSIONS =
@@ -179,7 +160,12 @@ export const DuckDBConnectionPoolProvider = ({
       URL.revokeObjectURL(workerBlobUrl.current);
       workerBlobUrl.current = null;
     }
-  }, [worker, workerBlobUrl]);
+
+    if (pthreadWorkerBlobUrl.current != null) {
+      URL.revokeObjectURL(pthreadWorkerBlobUrl.current);
+      pthreadWorkerBlobUrl.current = null;
+    }
+  }, [worker, workerBlobUrl, pthreadWorkerBlobUrl]);
 
   // terminate worker and revoke blob URL on unmount
   useEffect(
@@ -288,262 +274,470 @@ export const DuckDBConnectionPoolProvider = ({
 
         ensureNotCancelled();
 
-        // Resolve bundle
+        // The boot sequence for one selected bundle: worker creation, WASM
+        // instantiation and database open. Extracted so a failed COI
+        // (multithreaded) boot can retry with the single-threaded EH bundle.
+        // `reportErrors` suppresses terminal error status updates while a
+        // fallback attempt remains; console diagnostics are always emitted.
+        const bootDatabase = async (
+          bundle: duckdb.DuckDBBundle,
+          reportErrors: boolean,
+        ): Promise<duckdb.AsyncDuckDB> => {
+          // Create a blob URL for the worker script. The bootstrap installs a
+          // console filter that drops known-noisy MotherDuck wasm_extension logs
+          // before loading the real DuckDB worker.
+          if (!bundle.mainWorker) {
+            throw new Error('Selected DuckDB bundle is missing a worker URL.');
+          }
+          const worker_url = URL.createObjectURL(
+            new Blob([buildDuckDBWorkerBootstrap(bundle.mainWorker)], { type: 'text/javascript' }),
+          );
+
+          // Store the URL in the ref for cleanup on unmount
+          workerBlobUrl.current = worker_url;
+
+          // The COI bundle's pthread workers are spawned from inside the main
+          // DuckDB worker via `new Worker(pthreadWorkerUrl)`. Workers cannot be
+          // constructed from a cross-origin CDN URL, so wrap the pthread worker
+          // in the same same-origin blob bootstrap as the main worker (this also
+          // installs the console filter in every pthread worker).
+          let pthreadWorkerUrl: string | null = null;
+          if (bundle.pthreadWorker) {
+            pthreadWorkerUrl = URL.createObjectURL(
+              new Blob([buildDuckDBWorkerBootstrap(bundle.pthreadWorker)], {
+                type: 'text/javascript',
+              }),
+            );
+            pthreadWorkerBlobUrl.current = pthreadWorkerUrl;
+          }
+
+          // Create worker and database
+          let bootedDb: duckdb.AsyncDuckDB;
+          try {
+            worker.current = new Worker(worker_url);
+            bootedDb = new duckdb.AsyncDuckDB(logger, worker.current);
+            memoizedStatusUpdate({
+              state: 'loading',
+              message: 'Loading DuckDB... 0%',
+            });
+          } catch (e: any) {
+            const errorMessage = `Error setting up DuckDB worker: ${e.toString()}`;
+            console.error(errorMessage);
+            if (reportErrors) {
+              memoizedStatusUpdate({
+                state: 'error',
+                message: import.meta.env.DEV
+                  ? errorMessage
+                  : 'Failed to initialize database worker',
+              });
+            }
+            throw e; // Rethrow to trigger error handler
+          }
+
+          ensureNotCancelled();
+
+          // Instantiate DuckDB
+          try {
+            await bootedDb.instantiate(
+              bundle.mainModule,
+              pthreadWorkerUrl,
+              (p: duckdb.InstantiationProgress) => {
+                if (p.bytesLoaded > 0) {
+                  // Do not ask why * 10.0... taken from duckdb-wasm-shell, looks like either of the two
+                  // values have incorrect magnitude
+                  const progress = Math.max(
+                    Math.min(Math.ceil((p.bytesLoaded / p.bytesTotal) * 10.0), 100.0),
+                    0.0,
+                  );
+                  try {
+                    memoizedStatusUpdate({
+                      state: 'loading',
+                      message: `Loading DuckDB... ${progress}%`,
+                    });
+                  } catch (e: any) {
+                    console.warn(`progress handler failed with error: ${e.toString()}`);
+                  }
+                } else {
+                  memoizedStatusUpdate({
+                    state: 'loading',
+                    message: 'Loading DuckDB...',
+                  });
+                }
+              },
+            );
+          } catch (e: any) {
+            const errorMessage = `Error instantiating DuckDB: ${e.toString()}`;
+            console.error(errorMessage);
+            if (reportErrors) {
+              memoizedStatusUpdate({
+                state: 'error',
+                message: import.meta.env.DEV ? errorMessage : 'Failed to initialize database',
+              });
+            }
+            throw e; // Rethrow to trigger error handler
+          }
+
+          ensureNotCancelled();
+
+          // Open a database with the OPFS path - no fallback to in-memory
+          try {
+            memoizedStatusUpdate({
+              state: 'loading',
+              message: 'Opening persistent database...',
+            });
+
+            // Ensure the path format is correct and safe
+            let { dbPath } = persistenceState;
+
+            // Make sure the path starts with opfs://
+            if (!dbPath.startsWith('opfs://')) {
+              dbPath = `opfs://${dbPath.replace(/^opfs:/, '')}`;
+            }
+
+            // Validate the path to prevent path traversal attacks
+            if (!isSafeOpfsPath(dbPath)) {
+              const normalizedPath = normalizeOpfsPath(dbPath);
+              console.error('Invalid or unsafe database path detected');
+              throw new Error(
+                import.meta.env.DEV
+                  ? `Invalid or unsafe database path: ${normalizedPath}`
+                  : 'Invalid database configuration',
+              );
+            }
+
+            // Direct `opfs://` opens are not durable on the current
+            // duckdb-wasm version (upstream #2192) — register the OPFS file
+            // handles ourselves and open by registered name instead. See
+            // opfs-database-files.ts for the full background.
+            const registrationPlan = planOpfsDatabaseRegistration(dbPath);
+            if (!registrationPlan) {
+              console.warn(
+                `OPFS database path ${dbPath} is not eligible for direct file registration; ` +
+                  'falling back to opfs:// path handling, which is NOT durable on the current DuckDB-WASM version.',
+              );
+            }
+
+            // Log the path for debugging
+            if (import.meta.env.DEV) {
+              // eslint-disable-next-line no-console
+              console.debug(
+                'Opening DuckDB with path:',
+                dbPath,
+                registrationPlan ? `(registered as ${registrationPlan.registeredDbPath})` : '',
+              );
+            }
+
+            const openConfig: duckdb.DuckDBConfig = {
+              path: registrationPlan ? registrationPlan.registeredDbPath : dbPath,
+              accessMode: duckdb.DuckDBAccessMode.READ_WRITE,
+              allowUnsignedExtensions: ALLOW_UNSIGNED_EXTENSIONS,
+              // Required with registered OPFS handles so a fresh, empty file
+              // is treated as a new database instead of failing validation.
+              ...(registrationPlan ? { useDirectIO: true } : {}),
+              // Multithreaded (COI) engine only: DuckDB-WASM defaults to 4
+              // threads regardless of available cores.
+              ...(bundle.pthreadWorker
+                ? { maximumThreads: recommendedThreadCount(navigator.hardwareConcurrency) }
+                : {}),
+              query: {
+                // Enable Apache Arrow type and value patching DECIMAL -> DOUBLE on query materialization
+                // https://github.com/apache/arrow/issues/37920
+                castDecimalToDouble: true,
+              },
+            };
+
+            // A previous DuckDB worker (bundle-fallback retry, remount, or a
+            // just-closed tab) may still hold the OPFS sync access handle —
+            // Chromium releases a terminated worker's handles asynchronously.
+            // Retry this specific contention briefly instead of failing.
+            const OPEN_LOCK_RETRIES = 10;
+            const OPEN_LOCK_RETRY_DELAY_MS = 300;
+            for (let attempt = 1; ; attempt += 1) {
+              try {
+                if (registrationPlan) {
+                  const opfsRoot = await navigator.storage.getDirectory();
+                  const [dbFile, ...companionFiles] = registrationPlan.files;
+                  const dbFileHandle = await opfsRoot.getFileHandle(dbFile.opfsFileName, {
+                    create: true,
+                  });
+                  // Reset the WAL and checkpoint companions before every open.
+                  // DuckDB deletes the WAL file after a checkpoint, but the
+                  // WASM runtime's removeFile is a no-op — stale WAL
+                  // generations accumulate and a later open can abort with
+                  // "Invalid WAL entry type" while replaying the garbage tail
+                  // (or, for files from the broken opfs:// era, resurrect
+                  // ghost tables). WAL replay does not work in DuckDB-WASM
+                  // OPFS anyway (verified back to 1.33.1-dev20.0), so a
+                  // session always resumes from the last checkpoint.
+                  for (const companion of companionFiles) {
+                    await opfsRoot.removeEntry(companion.opfsFileName).catch(() => {});
+                  }
+                  await bootedDb.registerFileHandle(
+                    dbFile.registeredName,
+                    dbFileHandle,
+                    duckdb.DuckDBDataProtocol.BROWSER_FSACCESS,
+                    true,
+                  );
+                  for (const companion of companionFiles) {
+                    const companionHandle = await opfsRoot.getFileHandle(companion.opfsFileName, {
+                      create: true,
+                    });
+                    await bootedDb.registerFileHandle(
+                      companion.registeredName,
+                      companionHandle,
+                      duckdb.DuckDBDataProtocol.BROWSER_FSACCESS,
+                      true,
+                    );
+                  }
+                }
+                await bootedDb.open(openConfig);
+                break;
+              } catch (e: any) {
+                const message = e instanceof Error ? e.message : String(e);
+                const isHandleContention = /Access Handles cannot be created/i.test(message);
+                // Backstop for WAL states the pre-open reset cannot fix in
+                // place (e.g. the engine buffered the corrupt WAL before
+                // failing): drop and retry — the next attempt starts from
+                // freshly reset companions.
+                const isWalFailure = registrationPlan != null && isWalReplayFailure(message);
+                if ((!isHandleContention && !isWalFailure) || attempt >= OPEN_LOCK_RETRIES) {
+                  throw e;
+                }
+                if (isWalFailure) {
+                  console.warn(
+                    'DuckDB WAL was invalid and has been discarded; the database resumes from its last checkpoint.',
+                  );
+                }
+                // Release any partially-acquired handles from this attempt so
+                // the retry does not contend with itself.
+                await bootedDb.dropFiles().catch(() => {});
+                await new Promise((resolve) => {
+                  setTimeout(resolve, OPEN_LOCK_RETRY_DELAY_MS);
+                });
+                ensureNotCancelled();
+              }
+            }
+          } catch (e: any) {
+            // Handle connection error - no fallback to in-memory mode
+            const errorMessage = `Error opening persistent database: ${e.toString()}`;
+            console.error(errorMessage);
+            if (reportErrors) {
+              memoizedStatusUpdate({
+                state: 'error',
+                message: import.meta.env.DEV ? errorMessage : 'Failed to open persistent database',
+              });
+            }
+            throw e; // Rethrow to trigger error handler
+          }
+
+          return bootedDb;
+        };
+
+        // Resolve bundle — selectBundle prefers the multithreaded COI build
+        // when the page is cross-origin isolated and the browser supports WASM
+        // threads, exceptions and SIMD; otherwise it picks EH, then MVP.
         const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
 
         ensureNotCancelled();
 
-        // Create a blob URL for the worker script. The bootstrap installs a
-        // console filter that drops known-noisy MotherDuck wasm_extension logs
-        // before loading the real DuckDB worker.
-        if (!bundle.mainWorker) {
-          throw new Error('Selected DuckDB bundle is missing a worker URL.');
-        }
-        const worker_url = URL.createObjectURL(
-          new Blob([buildDuckDBWorkerBootstrap(bundle.mainWorker)], { type: 'text/javascript' }),
-        );
+        // Establishes a usable pool for one bundle: full database boot plus
+        // pool construction and the first (write-mode) queries. Grouped into
+        // one retryable unit because per-connection extension loading (httpfs)
+        // runs on first pool use — under COI a broken threaded extension build
+        // only surfaces there, after a successful boot.
+        const establishPool = async (
+          bootBundle: duckdb.DuckDBBundle,
+          reportErrors: boolean,
+        ): Promise<AsyncDuckDBConnectionPool> => {
+          const bootedDb = await bootDatabase(bootBundle, reportErrors);
 
-        // Store the URL in the ref for cleanup on unmount
-        workerBlobUrl.current = worker_url;
+          ensureNotCancelled();
 
-        // Create worker and database
-        let newDb: duckdb.AsyncDuckDB;
-        try {
-          worker.current = new Worker(worker_url);
-          newDb = new duckdb.AsyncDuckDB(logger, worker.current);
-          memoizedStatusUpdate({
-            state: 'loading',
-            message: 'Loading DuckDB... 0%',
-          });
-        } catch (e: any) {
-          const errorMessage = `Error setting up DuckDB worker: ${e.toString()}`;
-          console.error(errorMessage);
-          memoizedStatusUpdate({
-            state: 'error',
-            message: import.meta.env.DEV ? errorMessage : 'Failed to initialize database worker',
-          });
-          throw e; // Rethrow to trigger error handler
-        }
+          let bootedPool: AsyncDuckDBConnectionPool | null = null;
+          try {
+            // Create a connection pool with the update state callback (always persistent)
+            memoizedStatusUpdate({
+              state: 'loading',
+              message: 'Initializing connection pool...',
+            });
 
-        ensureNotCancelled();
-
-        // Instantiate DuckDB
-        try {
-          await newDb.instantiate(
-            bundle.mainModule,
-            bundle.pthreadWorker,
-            (p: duckdb.InstantiationProgress) => {
-              if (p.bytesLoaded > 0) {
-                // Do not ask why * 10.0... taken from duckdb-wasm-shell, looks like either of the two
-                // values have incorrect magnitude
-                const progress = Math.max(
-                  Math.min(Math.ceil((p.bytesLoaded / p.bytesTotal) * 10.0), 100.0),
-                  0.0,
-                );
+            // Create a connection pool with configurable checkpoint settings
+            bootedPool = new AsyncDuckDBConnectionPool(
+              bootedDb,
+              normalizedPoolSize,
+              updatePersistenceState, // Always use the persistence callback
+              {
+                // Default configuration that balances performance and data safety
+                throttleMs: import.meta.env.DEV ? 5000 : 10000, // More frequent in dev, less in prod
+                maxChangesBeforeForce: 100,
+                checkpointOnClose: true,
+                // Only log checkpoints in development mode
+                logCheckpoints: import.meta.env.DEV,
+                // Always checkpoint the persistent database by name: pooled
+                // connections may sit on another catalog (MotherDuck flows
+                // reset theirs to `USE memory`), and a bare FORCE CHECKPOINT
+                // would silently no-op for the persistent database.
+                checkpointDatabase: PERSISTENT_DB_NAME,
+              },
+              async (conn) => {
+                await configureConnectionForHttpfs(conn);
                 try {
-                  memoizedStatusUpdate({
-                    state: 'loading',
-                    message: `Loading DuckDB... ${progress}%`,
-                  });
-                } catch (e: any) {
-                  console.warn(`progress handler failed with error: ${e.toString()}`);
+                  await conn.query("ATTACH IF NOT EXISTS ':memory:' AS memory;");
+                } catch (error) {
+                  console.warn('Failed to attach per-connection memory catalog:', error);
                 }
-              } else {
-                memoizedStatusUpdate({
-                  state: 'loading',
-                  message: 'Loading DuckDB...',
-                });
-              }
-            },
-          );
-        } catch (e: any) {
-          const errorMessage = `Error instantiating DuckDB: ${e.toString()}`;
-          console.error(errorMessage);
-          memoizedStatusUpdate({
-            state: 'error',
-            message: import.meta.env.DEV ? errorMessage : 'Failed to initialize database',
-          });
-          throw e; // Rethrow to trigger error handler
-        }
+              },
+              {
+                onBeforeTabConnectionUse: async (tabId, conn) => {
+                  const tab = useAppStore.getState().tabs.get(tabId);
+                  if (tab?.type !== 'script') return;
 
-        ensureNotCancelled();
+                  const session = useAppStore.getState().sqlScriptSessions.get(tab.sqlScriptId);
+                  const next: CatalogSchemaSelection = session
+                    ? {
+                        catalog: session.currentCatalog,
+                        schema: session.currentSchema,
+                        searchPath: session.searchPath ?? null,
+                      }
+                    : {
+                        catalog: PERSISTENT_DB_NAME,
+                        schema: 'main',
+                        searchPath: null,
+                      };
 
-        // Open a database with the OPFS path - no fallback to in-memory
-        try {
-          memoizedStatusUpdate({
-            state: 'loading',
-            message: 'Opening persistent database...',
-          });
+                  const useStmt = buildUseStatement(next.catalog, next.schema);
+                  if (useStmt) {
+                    try {
+                      await conn.query(useStmt);
+                    } catch (error) {
+                      throw new Error(
+                        `Failed to restore DuckDB script session (${next.catalog ?? 'default'}${
+                          next.schema ? `.${next.schema}` : ''
+                        }). Select another session or reconnect the data source before running.`,
+                        { cause: error },
+                      );
+                    }
+                  }
+                  // Restore a multi-entry search_path captured after the run.
+                  // USE collapses the path to a single schema, so re-apply the
+                  // full path on top. Best-effort: a value DuckDB can't round-
+                  // trip must not abort the run — we keep the single schema USE
+                  // already set.
+                  const searchPathStmt = buildSearchPathStatement(next.searchPath);
+                  if (searchPathStmt) {
+                    try {
+                      await conn.query(searchPathStmt);
+                    } catch (error) {
+                      console.warn(
+                        'Failed to restore DuckDB search_path for script session:',
+                        error,
+                      );
+                    }
+                  }
 
-          // Ensure the path format is correct and safe
-          let { dbPath } = persistenceState;
+                  // Note: the transient flag is intentionally NOT cleared here.
+                  // This hook fires on every connection claim, including the
+                  // background re-read that happens when a user switches to an
+                  // evicted tab. Clearing it here would hide the "session
+                  // evicted" badge the instant the tab is viewed. The badge is
+                  // cleared at the start of the next run instead (see
+                  // script-tab-view), matching the eviction notice that catalog
+                  // and schema are restored on the next run.
+                },
+                onTabEvicted: (tabId) => {
+                  const tab = useAppStore.getState().tabs.get(tabId);
+                  if (tab?.type !== 'script') return;
 
-          // Make sure the path starts with opfs://
-          if (!dbPath.startsWith('opfs://')) {
-            dbPath = `opfs://${dbPath.replace(/^opfs:/, '')}`;
+                  markTransient(tab.sqlScriptId, true);
+                  showWarning({
+                    id: `duckdb-session-evicted-${tabId}`,
+                    title: 'Script session evicted',
+                    message:
+                      'This tab was inactive long enough for DuckDB to reuse its connection. Catalog and schema will be restored on the next run, but temp tables and SET values are not preserved.',
+                  });
+                },
+              },
+            );
+
+            /**
+             * WORKAROUND: Addresses an issue with OPFS (Origin Private File System) and write mode
+             * after a page reload in DuckDB-WASM.
+             *
+             * @problem When using DuckDB-WASM with OPFS for persistence, a problem arises where,
+             * after a page reload, the OPFS database, even if opened in READ_WRITE mode,
+             * does not always correctly restore its write-enabled state. This leads to an
+             * "Error: TransactionContext Error: Failed to commit: File is not opened in write mode"
+             * when attempting write operations (e.g., CREATE TABLE, INSERT) after the reload.
+             *
+             * @workaround To forcibly activate the write mode for OPFS during each
+             * initialization (including those after a page reload), a harmless sequence of write
+             * operations is performed: a temporary table with a unique name is created and
+             * then immediately dropped. This ensures that the connection to OPFS is genuinely
+             * ready for write operations before the application attempts any actual data-modifying queries.
+             *
+             * This workaround is a temporary measure pending a fix at the duckdb-wasm library level
+             * (see related issue, PR https://github.com/duckdb/duckdb-wasm/pull/1962).
+             */
+            const name = v4();
+            await bootedPool.query(`CREATE OR REPLACE TABLE "${name}" as select 1;`);
+            await bootedPool.query(`DROP TABLE "${name}";`);
+
+            return bootedPool;
+          } catch (e: any) {
+            // Stop the pool's checkpoint timers before the worker goes away.
+            try {
+              await bootedPool?.close();
+            } catch {
+              // best-effort cleanup of a half-initialized pool
+            }
+            const errorMessage = `Error getting DuckDB connection: ${e.toString()}`;
+            console.error(errorMessage);
+            if (reportErrors) {
+              memoizedStatusUpdate({
+                state: 'error',
+                message: import.meta.env.DEV
+                  ? errorMessage
+                  : 'Failed to initialize connection pool',
+              });
+            }
+            throw e; // Rethrow to trigger error handler
           }
+        };
 
-          // Validate the path to prevent path traversal attacks
-          if (!isSafeOpfsPath(dbPath)) {
-            const normalizedPath = normalizeOpfsPath(dbPath);
-            console.error('Invalid or unsafe database path detected');
-            throw new Error(
-              import.meta.env.DEV
-                ? `Invalid or unsafe database path: ${normalizedPath}`
-                : 'Invalid database configuration',
+        const usingCoi = isCoiBundleSelection(bundle, JSDELIVR_BUNDLES);
+        let pool: AsyncDuckDBConnectionPool;
+        try {
+          pool = await establishPool(bundle, !usingCoi);
+          if (usingCoi) {
+            // eslint-disable-next-line no-console
+            console.info(
+              `DuckDB-WASM running multithreaded (COI bundle, up to ${recommendedThreadCount(
+                navigator.hardwareConcurrency,
+              )} threads)`,
             );
           }
-
-          // Log the path for debugging
-          if (import.meta.env.DEV) {
-            // eslint-disable-next-line no-console
-            console.debug('Opening DuckDB with path:', dbPath);
+        } catch (e) {
+          // A COI initialization can fail for reasons the EH bundle does not
+          // share (pthread spawning, OPFS with threads, threaded extension
+          // builds), so retry once single-threaded rather than failing the app.
+          if (e instanceof DuckDBInitializationCancelledError || !usingCoi) {
+            throw e;
           }
-
-          await newDb.open({
-            path: dbPath,
-            accessMode: duckdb.DuckDBAccessMode.READ_WRITE,
-            allowUnsignedExtensions: ALLOW_UNSIGNED_EXTENSIONS,
-            query: {
-              // Enable Apache Arrow type and value patching DECIMAL -> DOUBLE on query materialization
-              // https://github.com/apache/arrow/issues/37920
-              castDecimalToDouble: true,
-            },
-          });
-        } catch (e: any) {
-          // Handle connection error - no fallback to in-memory mode
-          const errorMessage = `Error opening persistent database: ${e.toString()}`;
-          console.error(errorMessage);
-          memoizedStatusUpdate({
-            state: 'error',
-            message: import.meta.env.DEV ? errorMessage : 'Failed to open persistent database',
-          });
-          throw e; // Rethrow to trigger error handler
+          console.warn(
+            'Multithreaded DuckDB (COI) initialization failed; retrying with the single-threaded EH bundle:',
+            e,
+          );
+          cleanupWorkerResources();
+          const fallbackBundle = await duckdb.selectBundle(withoutCoiBundle(JSDELIVR_BUNDLES));
+          ensureNotCancelled();
+          pool = await establishPool(fallbackBundle, true);
         }
 
         ensureNotCancelled();
 
-        // Finally, get the connection
+        // Finally, finish initialization: leftover cleanup, optional
+        // extensions, and publishing the pool to the app.
         try {
-          // Create a connection pool with the update state callback (always persistent)
-          memoizedStatusUpdate({
-            state: 'loading',
-            message: 'Initializing connection pool...',
-          });
-
-          // Create a connection pool with configurable checkpoint settings
-          const pool = new AsyncDuckDBConnectionPool(
-            newDb,
-            normalizedPoolSize,
-            updatePersistenceState, // Always use the persistence callback
-            {
-              // Default configuration that balances performance and data safety
-              throttleMs: import.meta.env.DEV ? 5000 : 10000, // More frequent in dev, less in prod
-              maxChangesBeforeForce: 100,
-              checkpointOnClose: true,
-              // Only log checkpoints in development mode
-              logCheckpoints: import.meta.env.DEV,
-            },
-            async (conn) => {
-              await configureConnectionForHttpfs(conn);
-              try {
-                await conn.query("ATTACH IF NOT EXISTS ':memory:' AS memory;");
-              } catch (error) {
-                console.warn('Failed to attach per-connection memory catalog:', error);
-              }
-            },
-            {
-              onBeforeTabConnectionUse: async (tabId, conn) => {
-                const tab = useAppStore.getState().tabs.get(tabId);
-                if (tab?.type !== 'script') return;
-
-                const session = useAppStore.getState().sqlScriptSessions.get(tab.sqlScriptId);
-                const next: CatalogSchemaSelection = session
-                  ? {
-                      catalog: session.currentCatalog,
-                      schema: session.currentSchema,
-                      searchPath: session.searchPath ?? null,
-                    }
-                  : {
-                      catalog: PERSISTENT_DB_NAME,
-                      schema: 'main',
-                      searchPath: null,
-                    };
-
-                const useStmt = buildUseStatement(next.catalog, next.schema);
-                if (useStmt) {
-                  try {
-                    await conn.query(useStmt);
-                  } catch (error) {
-                    throw new Error(
-                      `Failed to restore DuckDB script session (${next.catalog ?? 'default'}${
-                        next.schema ? `.${next.schema}` : ''
-                      }). Select another session or reconnect the data source before running.`,
-                      { cause: error },
-                    );
-                  }
-                }
-                // Restore a multi-entry search_path captured after the run.
-                // USE collapses the path to a single schema, so re-apply the
-                // full path on top. Best-effort: a value DuckDB can't round-
-                // trip must not abort the run — we keep the single schema USE
-                // already set.
-                const searchPathStmt = buildSearchPathStatement(next.searchPath);
-                if (searchPathStmt) {
-                  try {
-                    await conn.query(searchPathStmt);
-                  } catch (error) {
-                    console.warn('Failed to restore DuckDB search_path for script session:', error);
-                  }
-                }
-
-                // Note: the transient flag is intentionally NOT cleared here.
-                // This hook fires on every connection claim, including the
-                // background re-read that happens when a user switches to an
-                // evicted tab. Clearing it here would hide the "session
-                // evicted" badge the instant the tab is viewed. The badge is
-                // cleared at the start of the next run instead (see
-                // script-tab-view), matching the eviction notice that catalog
-                // and schema are restored on the next run.
-              },
-              onTabEvicted: (tabId) => {
-                const tab = useAppStore.getState().tabs.get(tabId);
-                if (tab?.type !== 'script') return;
-
-                markTransient(tab.sqlScriptId, true);
-                showWarning({
-                  id: `duckdb-session-evicted-${tabId}`,
-                  title: 'Script session evicted',
-                  message:
-                    'This tab was inactive long enough for DuckDB to reuse its connection. Catalog and schema will be restored on the next run, but temp tables and SET values are not preserved.',
-                });
-              },
-            },
-          );
-
-          /**
-           * WORKAROUND: Addresses an issue with OPFS (Origin Private File System) and write mode
-           * after a page reload in DuckDB-WASM.
-           *
-           * @problem When using DuckDB-WASM with OPFS for persistence, a problem arises where,
-           * after a page reload, the OPFS database, even if opened in READ_WRITE mode,
-           * does not always correctly restore its write-enabled state. This leads to an
-           * "Error: TransactionContext Error: Failed to commit: File is not opened in write mode"
-           * when attempting write operations (e.g., CREATE TABLE, INSERT) after the reload.
-           *
-           * @workaround To forcibly activate the write mode for OPFS during each
-           * initialization (including those after a page reload), a harmless sequence of write
-           * operations is performed: a temporary table with a unique name is created and
-           * then immediately dropped. This ensures that the connection to OPFS is genuinely
-           * ready for write operations before the application attempts any actual data-modifying queries.
-           *
-           * This workaround is a temporary measure pending a fix at the duckdb-wasm library level
-           * (see related issue, PR https://github.com/duckdb/duckdb-wasm/pull/1962).
-           */
-          const name = v4();
-          await pool.query(`CREATE OR REPLACE TABLE "${name}" as select 1;`);
-          await pool.query(`DROP TABLE "${name}";`);
-
           // Cleanup any leftover UUID-named temporary tables from previous sessions
           try {
             // Query to find all tables with UUID-like names (36 chars with dashes in specific positions)
@@ -663,6 +857,34 @@ export const DuckDBConnectionPoolProvider = ({
     isTabBlocked,
     cleanupWorkerResources,
   ]);
+
+  // Flush pending changes to OPFS when the page is being hidden or unloaded
+  // (refresh, navigation, tab close/switch). DuckDB-WASM does not replay the
+  // OPFS WAL on the next load, so anything not yet checkpointed at unload
+  // would be lost; this best-effort flush closes most of that window.
+  useEffect(() => {
+    if (!connectionPool) {
+      return undefined;
+    }
+
+    const flush = () => {
+      connectionPool.flushPendingChanges().catch((error) => {
+        console.warn('Failed to flush pending DuckDB changes on page hide:', error);
+      });
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        flush();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pagehide', flush);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pagehide', flush);
+    };
+  }, [connectionPool]);
 
   useEffect(() => {
     if (!isTabBlocked) {

--- a/src/features/duckdb-context/opfs-database-files.ts
+++ b/src/features/duckdb-context/opfs-database-files.ts
@@ -1,0 +1,88 @@
+/**
+ * OPFS database file registration plan.
+ *
+ * DuckDB-WASM's direct `opfs://` database support is broken in the version
+ * line this app uses (duckdb-wasm 1.33.1-dev34.0+, upstream issue
+ * duckdb/duckdb-wasm#2192): DuckDB core collapses duplicate slashes in paths
+ * whose scheme it does not treat as remote (`opfs://x` → `opfs:/x`), so the
+ * engine-side file registry — populated under the original `opfs://x` name —
+ * misses, and the runtime silently falls back to an in-memory buffer
+ * ("Buffering missing file"). Queries succeed but nothing is ever written to
+ * OPFS: the database is lost on reload.
+ *
+ * The workaround: skip the `opfs://` path machinery entirely. We register the
+ * OPFS file handles ourselves under scheme-less names (nothing to collapse)
+ * and open the database by that registered name with `useDirectIO` (required
+ * so a fresh, empty OPFS file is treated as a new database instead of failing
+ * validation). Durability verified at checkpoint granularity — the same
+ * guarantee the last-good upstream version (1.33.1-dev20.0) provided.
+ *
+ * The registered name is prefixed with a pseudo-directory so it can never
+ * collide with user-added files, which are registered under their plain
+ * basenames (a basename cannot contain `/`). The catalog name DuckDB derives
+ * from the path basename is unaffected by the prefix.
+ */
+
+/** Pseudo-directory prefix for the main database's registered file names. */
+export const OPFS_DB_REGISTRATION_PREFIX = '__pondpilot__/';
+
+/**
+ * Companion files DuckDB may open next to a database file, derived by
+ * appending to the database path: the write-ahead log plus the checkpoint /
+ * recovery markers newer DuckDB versions use during WAL handling.
+ */
+const DB_FILE_SUFFIXES = ['', '.wal', '.wal.checkpoint', '.wal.recovery'];
+
+export interface OpfsDatabaseFileRegistration {
+  /** Name the file is registered under in DuckDB's file registry. */
+  registeredName: string;
+  /** File name inside the OPFS root directory. */
+  opfsFileName: string;
+}
+
+export interface OpfsDatabaseRegistrationPlan {
+  /** Path to pass to `db.open()` — the registered name of the database file. */
+  registeredDbPath: string;
+  /** All files to pre-register (database, WAL, WAL markers). */
+  files: OpfsDatabaseFileRegistration[];
+}
+
+/**
+ * Builds the registration plan for an `opfs://` database path.
+ *
+ * Only root-level OPFS files are supported (PondPilot always persists to
+ * `opfs://pondpilot.db`); returns null for nested or non-opfs paths so the
+ * caller can fall back to the library's own path handling.
+ */
+export function planOpfsDatabaseRegistration(
+  opfsDbPath: string,
+): OpfsDatabaseRegistrationPlan | null {
+  if (!opfsDbPath.startsWith('opfs://')) return null;
+
+  const fileName = opfsDbPath.slice('opfs://'.length);
+  if (!fileName || fileName.includes('/')) return null;
+
+  return {
+    registeredDbPath: `${OPFS_DB_REGISTRATION_PREFIX}${fileName}`,
+    files: DB_FILE_SUFFIXES.map((suffix) => ({
+      registeredName: `${OPFS_DB_REGISTRATION_PREFIX}${fileName}${suffix}`,
+      opfsFileName: `${fileName}${suffix}`,
+    })),
+  };
+}
+
+/**
+ * Returns true when a database open failed because DuckDB hit invalid data
+ * while replaying the WAL — e.g. "Failure while replaying WAL file ...:
+ * Invalid WAL entry type!".
+ *
+ * This happens with stale mixed-generation WAL bytes: DuckDB deletes the WAL
+ * file after a checkpoint, but the WASM runtime's removeFile is a no-op, so
+ * the next WAL generation is written from offset zero over older, longer
+ * content and a later replay runs past the valid entries into garbage.
+ * Recoverable by clearing the WAL companions and reopening — the database
+ * file itself holds everything up to the last checkpoint.
+ */
+export function isWalReplayFailure(message: string): boolean {
+  return /replaying WAL|Invalid WAL entry/i.test(message);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -23,6 +23,14 @@ interface ImportMetaEnv {
   /** Forces the MVP DuckDB-WASM bundle when set to "true". */
   readonly VITE_DUCKDB_WASM_FORCE_MVP?: string;
 
+  /**
+   * Enables the multithreaded COI DuckDB-WASM bundle when set to "true".
+   * Experimental: dynamic extensions (httpfs, iceberg, motherduck) cannot
+   * load under it until upstream ships linkable wasm_threads artifacts; a
+   * failed COI initialization falls back to the single-threaded EH bundle.
+   */
+  readonly VITE_DUCKDB_WASM_ENABLE_COI?: string;
+
   /** Allows unsigned DuckDB-WASM extensions when set to "true". */
   readonly VITE_DUCKDB_ALLOW_UNSIGNED_EXTENSIONS?: string;
 

--- a/tests/unit/duckdb-connection-pool/checkpoint-scheduling.test.ts
+++ b/tests/unit/duckdb-connection-pool/checkpoint-scheduling.test.ts
@@ -1,0 +1,193 @@
+import { AsyncDuckDBConnectionPool } from '@features/duckdb-context/duckdb-connection-pool';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+class FakeConnection {
+  public readonly calls: string[] = [];
+  public failQueries?: Set<string>;
+
+  constructor(public readonly id: number) {}
+
+  async query(sql: string) {
+    this.calls.push(sql);
+    if (this.failQueries?.has(sql)) {
+      throw new Error(`simulated query failure: ${sql}`);
+    }
+    return { toArray: () => [] };
+  }
+
+  async cancelSent() {
+    return false;
+  }
+
+  async close() {
+    this.calls.push('close');
+  }
+
+  async send() {
+    return {
+      async cancel() {
+        return undefined;
+      },
+      async next() {
+        return { done: true as const, value: null };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+  }
+
+  async prepare() {
+    return { close: async () => undefined };
+  }
+
+  async getTableNames() {
+    return [];
+  }
+}
+
+const THROTTLE_MS = 5000;
+
+const makePool = (checkpointDatabase?: string) => {
+  const connections: FakeConnection[] = [];
+  const bindings = {
+    connect: jest.fn(async () => {
+      const conn = new FakeConnection(connections.length);
+      connections.push(conn);
+      return conn;
+    }),
+  };
+  const updateStateCallback = jest.fn(async () => {});
+
+  const pool = new AsyncDuckDBConnectionPool(bindings as any, 4, updateStateCallback as any, {
+    throttleMs: THROTTLE_MS,
+    maxChangesBeforeForce: 100,
+    checkpointOnClose: false,
+    logCheckpoints: false,
+    ...(checkpointDatabase ? { checkpointDatabase } : {}),
+  });
+
+  return { pool, connections };
+};
+
+const checkpointCalls = (connections: FakeConnection[]): number =>
+  connections.reduce(
+    (sum, conn) => sum + conn.calls.filter((sql) => /FORCE CHECKPOINT/i.test(sql)).length,
+    0,
+  );
+
+describe('AsyncDuckDBConnectionPool checkpoint scheduling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('checkpoints throttled changes via timer even with no further releases', async () => {
+    const { pool, connections } = makePool();
+
+    // First write: time-since-last is large (epoch), checkpoints inline.
+    await pool.query('CREATE TABLE a AS SELECT 1');
+    expect(checkpointCalls(connections)).toBe(1);
+
+    // Second write lands inside the throttle window: inline checkpoint is
+    // skipped, so without the timer these changes would never be flushed.
+    await pool.query('CREATE TABLE b AS SELECT 1');
+    expect(checkpointCalls(connections)).toBe(1);
+
+    // No further pool activity — the deferred timer must fire the checkpoint.
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS + 50);
+    expect(checkpointCalls(connections)).toBe(2);
+  });
+
+  it('coalesces multiple throttled changes into a single deferred checkpoint', async () => {
+    const { pool, connections } = makePool();
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    await pool.query('CREATE TABLE b AS SELECT 1'); // throttled -> schedules
+    await pool.query('CREATE TABLE c AS SELECT 1'); // throttled -> coalesced
+    expect(checkpointCalls(connections)).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS + 50);
+    expect(checkpointCalls(connections)).toBe(2);
+
+    // Nothing further pending: no extra checkpoints fire later.
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS * 3);
+    expect(checkpointCalls(connections)).toBe(2);
+  });
+
+  it('flushPendingChanges checkpoints immediately when changes are pending', async () => {
+    const { pool, connections } = makePool();
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    await pool.query('CREATE TABLE b AS SELECT 1'); // throttled, pending
+
+    await expect(pool.flushPendingChanges()).resolves.toBe(true);
+    expect(checkpointCalls(connections)).toBe(2);
+
+    // No pending changes: resolves true without another checkpoint.
+    await expect(pool.flushPendingChanges()).resolves.toBe(true);
+    expect(checkpointCalls(connections)).toBe(2);
+  });
+
+  it('retries via timer when the deferred checkpoint fails', async () => {
+    const { pool, connections } = makePool();
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    await pool.query('CREATE TABLE b AS SELECT 1'); // throttled, pending
+
+    // Make the next FORCE CHECKPOINT fail once.
+    for (const conn of connections) {
+      conn.failQueries = new Set(['FORCE CHECKPOINT;']);
+    }
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS + 50);
+    expect(checkpointCalls(connections)).toBe(2); // attempted and failed
+
+    for (const conn of connections) {
+      conn.failQueries = undefined;
+    }
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS + 50);
+    expect(checkpointCalls(connections)).toBe(3); // retried and succeeded
+  });
+
+  it('targets the configured database explicitly, regardless of connection state', async () => {
+    const { pool, connections } = makePool('pondpilot');
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    const statements = connections.flatMap((conn) =>
+      conn.calls.filter((sql) => /CHECKPOINT/i.test(sql)),
+    );
+    // A pooled connection may sit on another catalog (e.g. MotherDuck flows
+    // reset theirs to `USE memory`) — a bare FORCE CHECKPOINT would no-op for
+    // the persistent database, so the target must be named.
+    expect(statements).toEqual(['FORCE CHECKPOINT pondpilot;']);
+  });
+
+  it('flushPendingChanges also targets the configured database', async () => {
+    const { pool, connections } = makePool('pondpilot');
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    await pool.query('CREATE TABLE b AS SELECT 1'); // throttled, pending
+    await pool.flushPendingChanges();
+
+    const statements = connections.flatMap((conn) =>
+      conn.calls.filter((sql) => /CHECKPOINT/i.test(sql)),
+    );
+    expect(statements).toEqual(['FORCE CHECKPOINT pondpilot;', 'FORCE CHECKPOINT pondpilot;']);
+  });
+
+  it('close clears the deferred checkpoint timer', async () => {
+    const { pool, connections } = makePool();
+
+    await pool.query('CREATE TABLE a AS SELECT 1'); // inline checkpoint
+    await pool.query('CREATE TABLE b AS SELECT 1'); // throttled -> schedules
+
+    await pool.close();
+    const callsAtClose = checkpointCalls(connections);
+
+    await jest.advanceTimersByTimeAsync(THROTTLE_MS * 2);
+    expect(checkpointCalls(connections)).toBe(callsAtClose);
+  });
+});

--- a/tests/unit/features/duckdb-context/duckdb-bundles.test.ts
+++ b/tests/unit/features/duckdb-context/duckdb-bundles.test.ts
@@ -1,0 +1,178 @@
+import type { DuckDBBundles } from '@duckdb/duckdb-wasm';
+import {
+  deriveCoiBundle,
+  isCoiBundleSelection,
+  recommendedThreadCount,
+  resolveDuckDBBundles,
+  withoutCoiBundle,
+} from '@features/duckdb-context/duckdb-bundles';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+
+const CDN_BASE = 'https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev53.0/dist/';
+
+const defaultBundles = (): DuckDBBundles => ({
+  mvp: {
+    mainModule: `${CDN_BASE}duckdb-mvp.wasm`,
+    mainWorker: `${CDN_BASE}duckdb-browser-mvp.worker.js`,
+  },
+  eh: {
+    mainModule: `${CDN_BASE}duckdb-eh.wasm`,
+    mainWorker: `${CDN_BASE}duckdb-browser-eh.worker.js`,
+  },
+});
+
+describe('duckdb-bundles', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('deriveCoiBundle', () => {
+    it('derives the COI artifact URLs from the MVP main module URL', () => {
+      expect(deriveCoiBundle(`${CDN_BASE}duckdb-mvp.wasm`)).toEqual({
+        mainModule: `${CDN_BASE}duckdb-coi.wasm`,
+        mainWorker: `${CDN_BASE}duckdb-browser-coi.worker.js`,
+        pthreadWorker: `${CDN_BASE}duckdb-browser-coi.pthread.worker.js`,
+      });
+    });
+
+    it('returns undefined for a URL that does not end in the MVP filename', () => {
+      expect(deriveCoiBundle(`${CDN_BASE}custom-build.wasm`)).toBeUndefined();
+    });
+
+    it('returns undefined for a URL without a path separator', () => {
+      expect(deriveCoiBundle('duckdb-mvp.wasm')).toBeUndefined();
+    });
+  });
+
+  describe('resolveDuckDBBundles', () => {
+    it('returns the default bundles unchanged when COI is not enabled', () => {
+      const bundles = defaultBundles();
+      expect(resolveDuckDBBundles(bundles, {})).toBe(bundles);
+    });
+
+    it('adds a derived COI entry when enableCoi is set', () => {
+      const resolved = resolveDuckDBBundles(defaultBundles(), { enableCoi: true });
+      expect(resolved.mvp).toEqual(defaultBundles().mvp);
+      expect(resolved.eh).toEqual(defaultBundles().eh);
+      expect(resolved.coi).toEqual({
+        mainModule: `${CDN_BASE}duckdb-coi.wasm`,
+        mainWorker: `${CDN_BASE}duckdb-browser-coi.worker.js`,
+        pthreadWorker: `${CDN_BASE}duckdb-browser-coi.pthread.worker.js`,
+      });
+    });
+
+    it('omits the COI entry when the MVP URL is not a standard dist layout', () => {
+      const bundles = defaultBundles();
+      bundles.mvp.mainModule = `${CDN_BASE}renamed.wasm`;
+      const resolved = resolveDuckDBBundles(bundles, { enableCoi: true });
+      expect(resolved.coi).toBeUndefined();
+    });
+
+    it('forceMvp keeps only the MVP bundle, even with enableCoi', () => {
+      const resolved = resolveDuckDBBundles(defaultBundles(), {
+        forceMvp: true,
+        enableCoi: true,
+      });
+      expect(resolved.mvp).toEqual(defaultBundles().mvp);
+      expect(resolved.eh).toBeUndefined();
+      expect(resolved.coi).toBeUndefined();
+    });
+
+    it('artifact URL overrides replace the EH/MVP entries and never offer COI', () => {
+      const resolved = resolveDuckDBBundles(defaultBundles(), {
+        mainModule: 'https://example.com/duckdb-eh.wasm',
+        mainWorker: 'https://example.com/duckdb-browser-eh.worker.js',
+        pthreadWorker: 'https://example.com/duckdb-browser-eh.pthread.worker.js',
+        enableCoi: true,
+      });
+      expect(resolved.mvp.mainModule).toBe('https://example.com/duckdb-eh.wasm');
+      expect(resolved.eh).toEqual({
+        mainModule: 'https://example.com/duckdb-eh.wasm',
+        mainWorker: 'https://example.com/duckdb-browser-eh.worker.js',
+        pthreadWorker: 'https://example.com/duckdb-browser-eh.pthread.worker.js',
+      });
+      expect(resolved.coi).toBeUndefined();
+    });
+
+    it('falls back to MVP artifacts and warns when EH defaults are unavailable', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const bundles = defaultBundles();
+      delete bundles.eh;
+      const resolved = resolveDuckDBBundles(bundles, {
+        pthreadWorker: 'https://example.com/pthread.worker.js',
+      });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(resolved.eh?.mainModule).toBe(bundles.mvp.mainModule);
+      expect((resolved.eh as { pthreadWorker?: string }).pthreadWorker).toBe(
+        'https://example.com/pthread.worker.js',
+      );
+    });
+  });
+
+  describe('isCoiBundleSelection', () => {
+    it('identifies a selected COI bundle by its main module URL', () => {
+      const bundles = resolveDuckDBBundles(defaultBundles(), { enableCoi: true });
+      const selected = {
+        mainModule: bundles.coi!.mainModule,
+        mainWorker: bundles.coi!.mainWorker,
+        pthreadWorker: bundles.coi!.pthreadWorker,
+      };
+      expect(isCoiBundleSelection(selected, bundles)).toBe(true);
+    });
+
+    it('returns false for an EH selection', () => {
+      const bundles = resolveDuckDBBundles(defaultBundles(), { enableCoi: true });
+      const selected = {
+        mainModule: bundles.eh!.mainModule,
+        mainWorker: bundles.eh!.mainWorker,
+        pthreadWorker: null,
+      };
+      expect(isCoiBundleSelection(selected, bundles)).toBe(false);
+    });
+
+    it('returns false when no COI bundle is offered', () => {
+      const bundles = defaultBundles();
+      const selected = {
+        mainModule: bundles.eh!.mainModule,
+        mainWorker: bundles.eh!.mainWorker,
+        pthreadWorker: null,
+      };
+      expect(isCoiBundleSelection(selected, bundles)).toBe(false);
+    });
+  });
+
+  describe('withoutCoiBundle', () => {
+    it('strips the COI entry and keeps MVP/EH', () => {
+      const bundles = resolveDuckDBBundles(defaultBundles(), { enableCoi: true });
+      const stripped = withoutCoiBundle(bundles);
+      expect(stripped.coi).toBeUndefined();
+      expect(stripped.mvp).toEqual(bundles.mvp);
+      expect(stripped.eh).toEqual(bundles.eh);
+    });
+
+    it('handles a bundle map without an EH entry', () => {
+      const stripped = withoutCoiBundle({ mvp: defaultBundles().mvp });
+      expect(stripped.eh).toBeUndefined();
+      expect(stripped.mvp).toEqual(defaultBundles().mvp);
+    });
+  });
+
+  describe('recommendedThreadCount', () => {
+    it('returns the floor of 2 when concurrency is unknown or tiny', () => {
+      expect(recommendedThreadCount(Number.NaN)).toBe(2);
+      expect(recommendedThreadCount(0)).toBe(2);
+      expect(recommendedThreadCount(1)).toBe(2);
+      expect(recommendedThreadCount(2)).toBe(2);
+    });
+
+    it('leaves one core for the main thread', () => {
+      expect(recommendedThreadCount(4)).toBe(3);
+      expect(recommendedThreadCount(8)).toBe(7);
+    });
+
+    it('caps at 8 threads on large machines', () => {
+      expect(recommendedThreadCount(16)).toBe(8);
+      expect(recommendedThreadCount(32)).toBe(8);
+    });
+  });
+});

--- a/tests/unit/features/duckdb-context/opfs-database-files.test.ts
+++ b/tests/unit/features/duckdb-context/opfs-database-files.test.ts
@@ -1,0 +1,82 @@
+import {
+  isWalReplayFailure,
+  OPFS_DB_REGISTRATION_PREFIX,
+  planOpfsDatabaseRegistration,
+} from '@features/duckdb-context/opfs-database-files';
+import { describe, it, expect } from '@jest/globals';
+
+describe('opfs-database-files', () => {
+  describe('planOpfsDatabaseRegistration', () => {
+    it('plans the database file plus WAL and WAL marker files', () => {
+      const plan = planOpfsDatabaseRegistration('opfs://pondpilot.db');
+      expect(plan).not.toBeNull();
+      expect(plan!.registeredDbPath).toBe(`${OPFS_DB_REGISTRATION_PREFIX}pondpilot.db`);
+      expect(plan!.files).toEqual([
+        {
+          registeredName: `${OPFS_DB_REGISTRATION_PREFIX}pondpilot.db`,
+          opfsFileName: 'pondpilot.db',
+        },
+        {
+          registeredName: `${OPFS_DB_REGISTRATION_PREFIX}pondpilot.db.wal`,
+          opfsFileName: 'pondpilot.db.wal',
+        },
+        {
+          registeredName: `${OPFS_DB_REGISTRATION_PREFIX}pondpilot.db.wal.checkpoint`,
+          opfsFileName: 'pondpilot.db.wal.checkpoint',
+        },
+        {
+          registeredName: `${OPFS_DB_REGISTRATION_PREFIX}pondpilot.db.wal.recovery`,
+          opfsFileName: 'pondpilot.db.wal.recovery',
+        },
+      ]);
+    });
+
+    it('keeps the catalog-relevant basename intact in the registered path', () => {
+      const plan = planOpfsDatabaseRegistration('opfs://pondpilot.db');
+      // DuckDB derives the catalog name from the path basename; the prefix is
+      // a pseudo-directory and must not change it.
+      expect(plan!.registeredDbPath.split('/').pop()).toBe('pondpilot.db');
+    });
+
+    it('returns null for non-opfs paths', () => {
+      expect(planOpfsDatabaseRegistration('pondpilot.db')).toBeNull();
+      expect(planOpfsDatabaseRegistration('http://example.com/x.db')).toBeNull();
+    });
+
+    it('returns null for nested opfs paths', () => {
+      expect(planOpfsDatabaseRegistration('opfs://dir/pondpilot.db')).toBeNull();
+    });
+
+    it('returns null for an empty opfs file name', () => {
+      expect(planOpfsDatabaseRegistration('opfs://')).toBeNull();
+    });
+
+    it('uses a pseudo-directory prefix that cannot collide with user file basenames', () => {
+      // User-added files are registered under their basenames, which can
+      // never contain a path separator.
+      expect(OPFS_DB_REGISTRATION_PREFIX).toContain('/');
+    });
+  });
+
+  describe('isWalReplayFailure', () => {
+    it('matches the WAL replay failure DuckDB raises on a stale WAL tail', () => {
+      expect(
+        isWalReplayFailure(
+          'Opening the database failed with error: {"exception_type":"INTERNAL",' +
+            '"exception_message":"Failure while replaying WAL file ' +
+            '\\"__pondpilot__/pondpilot.db.wal\\": Invalid WAL entry type!"}',
+        ),
+      ).toBe(true);
+      expect(isWalReplayFailure('Invalid WAL entry type!')).toBe(true);
+    });
+
+    it('does not match unrelated open failures', () => {
+      expect(
+        isWalReplayFailure(
+          'Access Handles cannot be created if there is another open Access Handle',
+        ),
+      ).toBe(false);
+      expect(isWalReplayFailure('IO Error: extension not available')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

DuckDB-WASM `dev34+` collapses duplicate slashes in `opfs://` paths (duckdb/duckdb-wasm#2192). After a page reload the database reopened under a different path and came up empty — **all OPFS-persisted data appeared lost** in production v0.9.0.

## Workaround (client-side, removable)

- Pre-register plain-name OPFS file handles with `useDirectIO` so the engine never re-derives the buggy path (`opfs-database-files.ts`, with a header documenting the upstream bug).
- Guard against stale WAL replay: a WAL replay failure discards the WAL and resumes from the last checkpoint instead of failing initialization.
- **Remove when upstream duckdb/duckdb-wasm#2197 ships.**

## Checkpoint hardening

- Checkpoints now name the persistent database explicitly — a bare `FORCE CHECKPOINT` only checkpoints the connection's *current* catalog, which silently no-ops when a pooled connection sits on another catalog (e.g. after MotherDuck flows `USE memory`).
- A coalesced deferred timer guarantees an upper bound between any write and its checkpoint, even when the write is the session's last connection release; failed checkpoints self-reschedule.
- `flushPendingChanges()` wired to page lifecycle (visibilitychange/pagehide) to shrink the WAL-only window before reload/close.

## Also included

- Opt-in COI multithreaded bundle resolution behind `VITE_DUCKDB_WASM_ENABLE_COI` with automatic fallback to the single-threaded EH bundle (dynamic extensions can't load under wasm_threads until upstream ships linkable artifacts, so default stays off).
- Docker nginx now sends the same COOP/COEP headers as `public/_headers` and the dev server.

## Testing

- 3 new unit suites: checkpoint scheduling (deferred timer, retry, no self-rearm), OPFS registration planning (WAL/recovery files, path edge cases), COI bundle resolution/fallback.
- Full unit suite: 1130/1130 pass. Typecheck/lint/prettier clean.
- Manually verified in June: data survives reload with the workaround; stale-WAL recovery exercised.