### PR TITLE
ci: add test retries, job timeouts, dependabot, and dependency audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - infra
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - infra

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +44,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Audit dependencies
+        run: yarn npm audit --environment production --severity high
+
       - name: Type check
         run: yarn typecheck
 
@@ -55,6 +59,7 @@ jobs:
   build-test:
     name: Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.repository == 'pondpilot/pondpilot' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     name: Lint & Build
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -77,6 +78,7 @@ jobs:
     if: github.repository == 'pondpilot/pondpilot' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     name: Deploy
+    timeout-minutes: 30
     needs: lint-and-build-prod
     permissions:
       contents: read
@@ -102,6 +104,7 @@ jobs:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
     name: Lookup Conclusion of Workflow_Run Event
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       conclusion: ${{ steps.get_conclusion.outputs.result }}
     steps:
@@ -124,6 +127,7 @@ jobs:
     needs: get_workflow_conclusion
     runs-on: ubuntu-latest
     name: Deploy
+    timeout-minutes: 30
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,7 @@ jobs:
   build-and-push:
     if: github.repository == 'pondpilot/pondpilot'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   testDir: './tests/integration',
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: parsedWorkersOverride ?? (process.env.CI ? 1 : '80%'),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
Four CI hardening changes from the July project audit:

- **Playwright retries on CI** (`retries: process.env.CI ? 2 : 0`): with 0 retries and a single serial worker, any flake hard-failed the whole PR run.
- **`timeout-minutes` on all workflow jobs** (lint 15, build-test 60, deploy/docker 30): previously a hang held a runner for GitHub's 6-hour default.
- **Dependabot**: weekly npm updates with minor+patch grouped into one PR (majors separate), weekly github-actions updates; PRs labeled `infra` so the changelog-label check passes.
- **Blocking dependency audit** in the lint job: `yarn npm audit --environment production --severity high` — verified passing against the current lockfile, so this lands green.

No source changes; YAML validated.