### PR TITLE
perf(build): split vendor chunks and enforce bundle size budget

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,6 +126,9 @@ jobs:
         env:
           VITE_BUG_REPORT_PROXY_URL: ${{ vars.VITE_BUG_REPORT_PROXY_URL }}
 
+      - name: Check bundle size
+        run: yarn check:bundle
+
       - name: Upload Build
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "check:bundle": "node scripts/check-bundle-size.mjs",
     "build:test": "yarn build --mode int-test-build",
     "test": "yarn build:test && playwright test",
     "test:no-build": "playwright test",

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,0 +1,68 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const assetsDirectory = path.resolve('dist/assets');
+const megabyte = 1024 * 1024;
+const maxChunkSize = 4 * megabyte;
+const maxTotalSize = 8 * megabyte;
+
+const formatSize = (bytes) => `${(bytes / megabyte).toFixed(2)} MB`;
+
+let assetNames;
+
+try {
+  assetNames = await readdir(assetsDirectory);
+} catch (error) {
+  console.error(`Could not read ${assetsDirectory}: ${error.message}`);
+  process.exit(1);
+}
+
+const chunks = await Promise.all(
+  assetNames
+    .filter((name) => name.endsWith('.js'))
+    .map(async (name) => ({
+      name,
+      size: (await stat(path.join(assetsDirectory, name))).size,
+    })),
+);
+
+if (chunks.length === 0) {
+  console.error(`No JavaScript chunks found in ${assetsDirectory}`);
+  process.exit(1);
+}
+
+chunks.sort((left, right) => right.size - left.size);
+
+const nameWidth = Math.max('Chunk'.length, ...chunks.map(({ name }) => name.length));
+const totalSize = chunks.reduce((total, { size }) => total + size, 0);
+
+console.log('JavaScript bundle sizes');
+console.log(`${'Chunk'.padEnd(nameWidth)}  Size`);
+console.log(`${'-'.repeat(nameWidth)}  --------`);
+
+for (const chunk of chunks) {
+  console.log(`${chunk.name.padEnd(nameWidth)}  ${formatSize(chunk.size).padStart(8)}`);
+}
+
+console.log(`${'-'.repeat(nameWidth)}  --------`);
+console.log(`${'Total'.padEnd(nameWidth)}  ${formatSize(totalSize).padStart(8)}`);
+
+const oversizedChunks = chunks.filter(({ size }) => size > maxChunkSize);
+
+if (oversizedChunks.length > 0 || totalSize > maxTotalSize) {
+  console.error('\nBundle size budget exceeded:');
+
+  for (const chunk of oversizedChunks) {
+    console.error(
+      `- ${chunk.name} is ${formatSize(chunk.size)} (limit: ${formatSize(maxChunkSize)})`,
+    );
+  }
+
+  if (totalSize > maxTotalSize) {
+    console.error(
+      `- Total JavaScript is ${formatSize(totalSize)} (limit: ${formatSize(maxTotalSize)})`,
+    );
+  }
+
+  process.exitCode = 1;
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,53 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { VitePWA } from 'vite-plugin-pwa';
 import svgr from 'vite-plugin-svgr';
 
+const getNodeModulesPackage = (id) => {
+  const normalizedId = id.replaceAll('\\', '/');
+  const nodeModulesIndex = normalizedId.lastIndexOf('/node_modules/');
+
+  if (nodeModulesIndex === -1) {
+    return undefined;
+  }
+
+  const [scopeOrName, scopedName] = normalizedId
+    .slice(nodeModulesIndex + '/node_modules/'.length)
+    .split('/');
+
+  return scopeOrName.startsWith('@')
+    ? `${scopeOrName}/${scopedName}`
+    : scopeOrName;
+};
+
+const manualChunks = (id) => {
+  const packageName = getNodeModulesPackage(id);
+
+  if (packageName === 'monaco-editor' || packageName === '@monaco-editor/react') {
+    return 'monaco';
+  }
+
+  if (packageName?.startsWith('@mantine/')) {
+    return 'mantine';
+  }
+
+  if (packageName === 'reactflow' || packageName === '@dagrejs/dagre') {
+    return 'flow';
+  }
+
+  if (packageName === 'recharts') {
+    return 'charts';
+  }
+
+  if (packageName === 'apache-arrow') {
+    return 'arrow';
+  }
+
+  if (packageName === '@duckdb/duckdb-wasm') {
+    return 'duckdb';
+  }
+
+  return undefined;
+};
+
 const getVersionInfo = () => {
   try {
     const packageJson = require('./package.json');
@@ -153,6 +200,11 @@ export default defineConfig(({ mode }) => {
 
     build: {
       sourcemap: mode === 'development',
+      rollupOptions: {
+        output: {
+          manualChunks,
+        },
+      },
     },
     optimizeDeps: {
       exclude: ['@duckdb/duckdb-wasm'],


### PR DESCRIPTION
From the July audit: the production build emitted a **single 6.81 MB JS chunk** (no `rollupOptions` at all), so every release invalidated the entire bundle for returning users and there was no guardrail against growth.

## Changes

- **`manualChunks`** in `vite.config.mjs` splits heavy, stable vendors into cache-friendly chunks (function form, whole packages only — no catch-all vendor chunk, avoiding the classic init-order footgun):

| Chunk | Size |
|---|---|
| monaco | 3.75 MB |
| index (app) | 2.20 MB |
| charts (recharts) | 0.39 MB |
| mantine | 0.33 MB |
| flow (reactflow+dagre) | 0.17 MB |
| arrow | 0.16 MB |
| duckdb | 0.02 MB |
| **Total** | **7.03 MB** (was 6.81 MB monolith) |

- **`scripts/check-bundle-size.mjs`** + `yarn check:bundle`: fails if any chunk exceeds 4 MB or total JS exceeds 8 MB; wired into CI after the production build.

## Verification

- Boot smoke test (real query round-trip via Playwright) passes against the split build — no chunk init-order breakage.
- typecheck / eslint clean; chunk dependency graph verified acyclic.

## Review note

The implementer initially also aliased `monaco-editor` → bare `editor.api.js` (saving ~1.5 MB) — **rejected during review**: the app uses Monaco's built-in `'sql'` language, and the bare entry drops the language contributions, silently killing SQL syntax highlighting. Trimming Monaco via explicit feature/language imports is a worthwhile follow-up with proper editor verification.

## Follow-up candidates
- Trim Monaco to needed features/languages (~1.5 MB potential)
- Lazy-load comparison / schema-browser features via dynamic import