### PR TITLE
fix(security): align nginx headers and add report-only CSP

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,9 +10,19 @@ server {
     gzip_min_length 1024;
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
 
+    # Cache headers are set here so location-specific cache policies do not
+    # prevent the security headers below from being inherited.
+    set $cache_control "";
+    set $pragma "";
+    set $expires "";
+    add_header Cache-Control $cache_control always;
+    add_header Pragma $pragma always;
+    add_header Expires $expires always;
+
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
     # Cross-origin isolation: required for SharedArrayBuffer (MotherDuck
@@ -21,10 +31,22 @@ server {
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Cross-Origin-Embedder-Policy "credentialless" always;
 
+    # Report-only during the bake period for observation in DevTools/the Reporting API; enforce after violations are resolved.
+    # connect-src intentionally permits HTTP(S) for arbitrary DuckDB HTTPFS and user-configured AI endpoints.
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.sheetjs.com https://extensions.duckdb.org https://community-extensions.duckdb.org https://ext.motherduck.com; worker-src 'self' blob:; connect-src https: http:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" always;
+
+    # PWA control files - no caching for immediate updates
+    location ~* ^/(sw\.js|registerSW\.js|manifest\.webmanifest)$ {
+        set $cache_control "no-cache, no-store, must-revalidate";
+        set $pragma "no-cache";
+        set $expires "0";
+        try_files $uri =404;
+    }
+
     # Serve static files directly
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
-        add_header Cache-Control "public, immutable";
+        set $cache_control "public, immutable";
         try_files $uri =404;
     }
 

--- a/public/_headers
+++ b/public/_headers
@@ -82,3 +82,6 @@
   X-XSS-Protection: 1; mode=block
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: credentialless
+  # Report-only during the bake period for observation in DevTools/the Reporting API; enforce after violations are resolved.
+  # connect-src intentionally permits HTTP(S) for arbitrary DuckDB HTTPFS and user-configured AI endpoints.
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.sheetjs.com https://extensions.duckdb.org https://community-extensions.duckdb.org https://ext.motherduck.com; worker-src 'self' blob:; connect-src https: http:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'


### PR DESCRIPTION
Security-header work from the July audit. No enforcement changes — the CSP is **report-only** for a bake period.

## Docker nginx ↔ Cloudflare `_headers` alignment
- `X-Frame-Options: DENY` (nginx sent `SAMEORIGIN`, Cloudflare sent `DENY`)
- Adds missing `Referrer-Policy: strict-origin-when-cross-origin`
- PWA control files (`sw.js`, `registerSW.js`, `manifest.webmanifest`) get explicit no-cache in nginx — previously the `*.js` 1-year-immutable rule would have pinned a stale service worker if Docker builds ever enable PWA

## Pre-existing bug fixed
nginx `add_header` at location level **drops all inherited server-level headers** — the static-asset cache rule was silently stripping every security header from JS/CSS/font responses. Converted to the canonical variable pattern (`set $cache_control` per location, single `add_header ... always` set at server level).

## Report-only CSP (identical on both surfaces)
`script-src` allowlists only the module CDNs the app actually loads from (derived from the code: jsdelivr, sheetjs, extensions.duckdb.org, community-extensions, ext.motherduck.com) + `'wasm-unsafe-eval'`; `worker-src blob:` for the worker bootstrap; `connect-src` intentionally broad (users point DuckDB httpfs / AI providers at arbitrary endpoints — commented inline). This is the compensating control for `allowUnsignedExtensions: true`: same-origin XSS is the one threat the encrypted secret store can't resist, and script-src is the layer that blocks it.

Promotion path: observe violations in DevTools/Reporting API, then flip to enforcing `Content-Security-Policy`.

## Verification
- `nginx -t` passes in `nginx:alpine` with this config
- Policy strings byte-identical between nginx and `_headers`