### PR TITLE
test: add coverage measurement with ratchet thresholds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,7 +90,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Run unit tests
-        run: yarn test:unit
+        run: yarn test:unit:coverage
         env:
           CI: true
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,18 @@ module.exports = {
   },
   roots: ['<rootDir>/tests/unit'],
   setupFiles: ['<rootDir>/tests/unit/jest-setup.js'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+  coverageProvider: 'v8',
+  coverageReporters: ['text-summary', 'lcov'],
+  // This is a ratchet — raise it as coverage grows, never lower it.
+  coverageThreshold: {
+    global: {
+      statements: 50,
+      branches: 81,
+      functions: 38,
+      lines: 50,
+    },
+  },
   globals: {
     'import.meta.env.DEV': false,
     'import.meta.env.PROD': true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:no-build": "playwright test",
     "test:docker": "./docker-playwright.sh test",
     "test:unit": "jest",
+    "test:unit:coverage": "jest --coverage",
     "test:all": "yarn test:unit && yarn test",
     "preview": "yarn build --mode int-test-build && vite preview",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
From the July audit: no coverage measurement or gating existed anywhere.

- `jest.config.js`: coverage config (V8 provider — Istanbul instrumentation breaks the self-serializing worker-function test), `text-summary` + `lcov` reporters, and **ratchet thresholds** set one point below today's measured baseline:

| Metric | Baseline | Threshold |
|---|---|---|
| statements | 51.81% | 50% |
| branches | 82.58% | 81% |
| functions | 39.4% | 38% |
| lines | 51.81% | 50% |

- `yarn test:unit` unchanged (no coverage, fast); new `yarn test:unit:coverage` used by CI, so any PR that drops coverage below baseline fails.
- The ratchet philosophy is documented in a comment: raise as coverage grows, never lower.

Verified: full unit suite passes both with and without coverage (1130 tests).