### PR TITLE
ci(docker): allow dispatching versioned image builds for released tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,14 @@ on:
       - 'v*.*.*'
   release:
     types: [published]
+  # Releases published by the release workflow use GITHUB_TOKEN, whose events
+  # do not trigger other workflows. Dispatch this manually for those tags.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released version to build an image for (e.g. 0.10.0, without the v prefix)'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -28,6 +36,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # For manual dispatch, build the released tag rather than the branch
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
 
       # Build app
       - name: Setup Node.js
@@ -65,7 +76,9 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "release" && "${{ github.ref_name }}" == v* ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.ref_name }}" == v* ]]; then
             echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
           else
             echo "version=" >> $GITHUB_OUTPUT
@@ -87,7 +100,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,event=tag,pattern={{version}}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.event_name == 'release' && steps.version.outputs.version != '' }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
Gap found while releasing v0.10.0: `release.yml` publishes the release with `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from `GITHUB_TOKEN` events — so `docker-build.yml`'s `release: [published]` trigger never fires for workflow-published releases. Previous versioned images (`0.3.0`–`0.9.0` on ghcr) exist because those releases were published by a human in the UI; #289's dry_run fix made workflow-publishing actually work, exposing this.

Remediation options were exhausted: the tag ruleset blocks delete/re-push of `v*` tags, and releases are **immutable**, so the `published` event can't be replayed.

## Change
- `workflow_dispatch` with a `version` input (e.g. `0.10.0`)
- checkout of `v{version}` tag on dispatch (branch ref otherwise, unchanged)
- version extraction handles the dispatch case; the `type=raw` image tag enables whenever a version is present (release **or** dispatch)

Push/PR/release trigger behavior is unchanged. After merge I'll dispatch it for `0.10.0` to backfill the missing image.