### PR TITLE
fix(comparison): checkpoint results so they survive reload

### DIFF
--- a/src/features/comparison/hooks/use-comparison-execution.ts
+++ b/src/features/comparison/hooks/use-comparison-execution.ts
@@ -401,6 +401,14 @@ const handleComparisonSuccess = async (
       result.metrics && result.metrics.type === 'hash-diff' ? result.metrics.stats : undefined,
   });
 
+  // Ensure comparison results are durably persisted before surfacing them.
+  const persisted = await pool.flushPendingChanges();
+  if (!persisted) {
+    console.error(
+      `Failed to force checkpoint after comparison ${comparisonId} (table ${tableName}) execution. Results may be lost on reload until next checkpoint.`,
+    );
+  }
+
   setComparisonPartialResults(comparisonId, false);
 
   return { tableName: tableName!, durationSeconds };

--- a/tests/integration/comparison/comparison.spec.ts
+++ b/tests/integration/comparison/comparison.spec.ts
@@ -101,6 +101,36 @@ const waitForComparisonConfigurationToPersist = async (page: Page) => {
     .toBe(true);
 };
 
+const waitForComparisonResultsToPersist = async (page: Page) => {
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          new Promise<boolean>((resolve, reject) => {
+            const request = indexedDB.open('app-data');
+
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => {
+              const database = request.result;
+              const transaction = database.transaction('comparison', 'readonly');
+              const comparisonsRequest = transaction.objectStore('comparison').getAll();
+
+              transaction.onerror = () => reject(transaction.error);
+              transaction.oncomplete = () => {
+                const comparisons = comparisonsRequest.result as Array<{
+                  resultsTableName?: string | null;
+                }>;
+
+                database.close();
+                resolve(comparisons.some((comparison) => Boolean(comparison.resultsTableName)));
+              };
+            };
+          }),
+      ),
+    )
+    .toBe(true);
+};
+
 test.describe('Comparison', () => {
   test.beforeEach(async ({ setupFileSystem, waitForFilesToBeProcessed }) => {
     await setupFileSystem(sourceFiles);
@@ -201,17 +231,15 @@ test.describe('Comparison', () => {
     selectMultipleFileNodes,
   }) => {
     await createComparisonFromSelectedFiles(page, selectMultipleFileNodes);
+    await runComparison(page);
+    await waitForComparisonResultsToPersist(page);
     await waitForComparisonConfigurationToPersist(page);
 
     await reloadPage();
 
-    await expect(page.getByText('Schema Comparison', { exact: true })).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'pondpilot.main.source_a', exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'pondpilot.main.source_b', exact: true }),
-    ).toBeVisible();
-    await expect(page.getByRole('checkbox', { name: 'id', exact: true })).toBeChecked();
+    await expect(page.getByText('Comparison Summary', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText('Schema Comparison', { exact: true })).toBeHidden();
   });
 });


### PR DESCRIPTION
Fixes #311 (found by the test suite added in #310).

## Root cause
Comparison results **are** materialized into the persistent `pondpilot` database — but no checkpoint ran between materialization and a reload. The wasm OPFS runtime never replays the WAL (checkpoint-granularity durability, same model as #292), so the results table vanished on reload while the IndexedDB metadata referencing it survived → “Comparison results missing”, back to config screen.

## Fix
One call: `await pool.flushPendingChanges()` after successful comparison completion (the checkpoint API added in #292), with a logged error if the checkpoint reports failure rather than silence.

## Tests
- Integration test 6 upgraded from asserting configuration-only persistence to asserting **actual results restoration after reload** — its original intent.
- Comparison suite 6/6 (verified independently), plus data-explorer/db-explorer/add-files specs (24 total) to guard the adjacent flows.
- typecheck / unit+coverage (1177 tests) / eslint 0 errors / prettier clean.