### PR TITLE
perf(startup): flip app-ready after local restore, hydrate the rest in background

### DIFF
--- a/src/features/app-context/hooks/use-init-application.tsx
+++ b/src/features/app-context/hooks/use-init-application.tsx
@@ -281,24 +281,51 @@ export function useAppInitialization({
         showPermsAlert(),
       );
 
-      // Load DuckDB functions into the store
-      await loadDuckDBFunctions(resolvedConn);
+      // Report we're ready for user interactions now.
+      setAppLoadState('ready');
 
-      // Install CORS proxy macros
-      try {
-        await installCorsProxyMacros(resolvedConn);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.warn('Failed to install CORS proxy macros:', message);
-        showWarning({
-          title: 'CORS Proxy Initialization Warning',
-          message:
-            'CORS proxy macros could not be installed. Remote databases may require manual configuration.',
-        });
-      }
+      (async () => {
+        try {
+          // Load DuckDB functions into the store
+          await loadDuckDBFunctions(resolvedConn);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error('Failed to load DuckDB functions:', message);
+          showWarning({
+            title: 'DuckDB Functions Initialization Warning',
+            message:
+              'DuckDB function metadata could not be loaded. Some editor help and validation may be incomplete.',
+          });
+        }
 
-      // Reconnect to remote databases
-      await reconnectRemoteDatabases(resolvedConn);
+        // Install CORS proxy macros
+        try {
+          await installCorsProxyMacros(resolvedConn);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.warn('Failed to install CORS proxy macros:', message);
+          showWarning({
+            title: 'CORS Proxy Initialization Warning',
+            message:
+              'CORS proxy macros could not be installed. Remote databases may require manual configuration.',
+          });
+        }
+
+        // Reconnect to remote databases
+        try {
+          await reconnectRemoteDatabases(resolvedConn);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error('Failed to reconnect remote databases:', message);
+          showWarning({
+            title: 'Remote Database Reconnect Warning',
+            message:
+              'Some remote databases could not be reconnected at startup. They can be retried from the data explorer.',
+          });
+        }
+      })().catch((error) => {
+        console.error('Unexpected error during background app initialization:', error);
+      });
 
       // TODO: more detailed/better message
       if (discardedEntries.length) {
@@ -352,9 +379,6 @@ export function useAppInitialization({
         message: `Failed to restore app data. ${message}`,
       });
     }
-
-    // Report we are ready
-    setAppLoadState('ready');
   };
 
   useEffect(() => {
@@ -367,6 +391,10 @@ export function useAppInitialization({
     // As of today, if the File Access API is not supported,
     // we are not initializing either in-memory DuckDB or the app data.
     if (!isFileAccessApiSupported || isMobileDevice) return;
+
+    if (useAppStore.getState().appLoadState === 'ready') {
+      return;
+    }
 
     // Start initialization of data when the database is ready
     if (conn) {


### PR DESCRIPTION
Stage 1 of the startup-performance work (requested by Sasha; boot-path analysis in session notes). With many data sources — especially any unreachable remote — the UI sat in skeletons for the whole init sequence.

## Before
`appLoadState → 'ready'` only after: local restore → `loadDuckDBFunctions` → CORS macros → **sequential** `reconnectRemoteDatabases` (per remote: up to 3 retries × 30s timeout → one dead remote ≈ 90s of skeleton UI). Every pane (explorer, scripts, tabs, action buttons) gates on this single flip.

## After
`'ready'` flips immediately after local sources are restored and attached. Function metadata, CORS macros, and remote reconnects run as background tasks — each with its own try/catch + user-visible warning (no unhandled rejections). Remote sources show their existing live `connecting/connected/error` states in the explorer while hydrating; MotherDuck-before-Quack ordering preserved (loop internals untouched in this stage).

## Hazard analysis (from the boot exploration)
- **Restored sessions referencing unattached catalogs**: verified self-healing — the `USE` restore in `onBeforeTabConnectionUse` retries on every use, so a query during the hydration window fails once with a clear message and works after attach. No pool changes needed.
- **Re-entry guard**: the init effect now skips when already `'ready'`; all pool-teardown paths reset to `'init'` before nulling the pool, so crash-recovery re-init is unaffected (verified in `duckdb-context.tsx` cleanup).

## Verification
- Full Chromium integration suite: green except the 7 known local-only bug-report failures (missing `VITE_BUG_REPORT_PROXY_URL`) and 2 known parallel-load flakes that pass on narrow rerun (ai-assistant 19/19, data-display 3/3).
- `script/` + `per-tab-session` suites (session-restore safety): 25 passed.
- typecheck ✓ · unit+coverage 82.04% branches ✓ · eslint 0 errors ✓ · prettier ✓

## Next stages (separate PRs)
Stage 2: lazy per-source metadata hydration. Stage 3: render source-independent panes before DuckDB boot completes.