### PR TITLE
perf(editor): import only needed Monaco features and languages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,8 @@ import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import 'allotment/dist/style.css';
 
+import '@features/editor/monaco-setup';
+
 import './index.css';
 
 import { ModifierProvider } from '@components/modifier-context/modifier-context';

--- a/src/controllers/sql-formatter.ts
+++ b/src/controllers/sql-formatter.ts
@@ -1,7 +1,7 @@
 import { showSuccess, showError } from '@components/app-notifications';
+import type { monaco } from '@features/editor/monaco-setup';
 import { SQLScript } from '@models/sql-script';
 import { formatSQLSafe } from '@utils/sql-formatter';
-import type * as monaco from 'monaco-editor';
 
 import { updateSQLScriptContent } from './sql-script';
 

--- a/src/features/editor/ai-assistant-tooltip.ts
+++ b/src/features/editor/ai-assistant-tooltip.ts
@@ -1,5 +1,5 @@
+import { monaco } from '@features/editor/monaco-setup';
 import { AsyncDuckDBConnectionPool } from '@services/duckdb-pool/duckdb-connection-pool';
-import * as monaco from 'monaco-editor';
 
 import { createAIAssistantHandlers } from './ai-assistant/ai-assistant-handlers';
 import { UI_SELECTORS } from './ai-assistant/constants';

--- a/src/features/editor/monaco-setup.ts
+++ b/src/features/editor/monaco-setup.ts
@@ -1,0 +1,20 @@
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+
+import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js';
+import 'monaco-editor/esm/vs/editor/browser/widget/diffEditor/diffEditor.contribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching.js';
+import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js';
+import 'monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js';
+import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js';
+import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
+import 'monaco-editor/esm/vs/editor/contrib/folding/browser/folding.js';
+import 'monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/multicursor/browser/multicursor.js';
+import 'monaco-editor/esm/vs/editor/contrib/parameterHints/browser/parameterHints.js';
+import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController.js';
+import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.js';
+
+loader.config({ monaco });
+
+export { monaco };

--- a/src/features/editor/sql-editor.tsx
+++ b/src/features/editor/sql-editor.tsx
@@ -19,7 +19,6 @@ import {
   isLintIssue,
   shouldDisplayLintIssue,
 } from '@utils/lint-config';
-import * as monaco from 'monaco-editor';
 import {
   forwardRef,
   useCallback,
@@ -32,6 +31,7 @@ import {
 
 import { registerAIAssistant, showAIAssistant, hideAIAssistant } from './ai-assistant-tooltip';
 import { useEditorTheme } from './hooks';
+import { monaco } from './monaco-setup';
 import {
   CancelledError,
   getFlowScopeClient,

--- a/src/features/script-editor/components/version-history/components/version-diff-editor.tsx
+++ b/src/features/script-editor/components/version-history/components/version-diff-editor.tsx
@@ -1,10 +1,10 @@
 import { useEditorTheme } from '@features/editor/hooks';
+import { monaco } from '@features/editor/monaco-setup';
 import { useAppTheme } from '@hooks/use-app-theme';
 import { Text } from '@mantine/core';
 import { ScriptVersion } from '@models/script-version';
 import { DiffEditor } from '@monaco-editor/react';
 import { setDataTestId } from '@utils/test-id';
-import * as monaco from 'monaco-editor';
 import { useEffect, useRef } from 'react';
 
 const EDITOR_OPTIONS: monaco.editor.IDiffEditorOptions = {
@@ -38,10 +38,8 @@ export const VersionDiffEditor = ({
   // Define theme for DiffEditor
   useEffect(() => {
     if (!themeDefinedRef.current && typeof window !== 'undefined') {
-      import('monaco-editor').then((monacoModule) => {
-        monacoModule.editor.defineTheme(themeName, themeData as monaco.editor.IStandaloneThemeData);
-        themeDefinedRef.current = true;
-      });
+      monaco.editor.defineTheme(themeName, themeData as monaco.editor.IStandaloneThemeData);
+      themeDefinedRef.current = true;
     }
   }, [themeName, themeData]);
 

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -19,6 +19,7 @@ import {
   isAIAssistantVisible,
 } from '@features/editor/ai-assistant-tooltip';
 import { convertToFlowScopeSchema } from '@features/editor/auto-complete';
+import { monaco } from '@features/editor/monaco-setup';
 import { useAppTheme } from '@hooks/use-app-theme';
 import { Group } from '@mantine/core';
 import { useDebouncedCallback, useDidUpdate } from '@mantine/hooks';
@@ -31,7 +32,6 @@ import { convertFunctionsToTooltips } from '@utils/convert-functions-to-tooltip'
 import { KEY_BINDING } from '@utils/hotkey/key-matcher';
 import { getScriptMetadata } from '@utils/script-version';
 import { setDataTestId } from '@utils/test-id';
-import * as monaco from 'monaco-editor';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 import { ScriptEditorDataStatePane } from './components';


### PR DESCRIPTION
Follow-up to #301, doing properly what the rejected `editor.api` alias attempted: the five `import * as monaco from 'monaco-editor'` sites pulled the full `editor.main` entry with every language Monaco ships. A central setup module now imports `editor.api` + explicit contributions (SQL basic-language, find, folding, hover, suggest, parameter hints, context menu, clipboard, comment, bracket matching, word highlighter, multicursor, diff editor).

## Size
| | before | after |
|---|---|---|
| monaco chunk | 3.75 MB | **2.81 MB** |
| total JS | 7.03 MB | **6.10 MB** |

## Verification (the part the rejected alias skipped)
Driven in a real browser against the built app, with screenshots: SQL syntax highlighting (tokens colored, not just text) ✓ · Ctrl+F find widget ✓ · folding affordances ✓ · autocomplete popup ✓ · right-click context menu ✓ · version-history side-by-side diff ✓ · end-to-end query run ✓. I independently reviewed the highlighting and diff-editor screenshots.

Suites: `script/` + `spotlight/` integration (31 passed), unit+coverage (1177 tests, branches ≥80), typecheck, eslint 0 errors, prettier. Import wiring only — no editor behavior or options changed.