### PR TITLE
chore(deps): flowscope-core 0.7, restore Monaco code-action contribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ tests/test-tmp
 
 # WASM build artifacts
 /public/wasm/
+.tmp/

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@mantine/notifications": "8.2.3",
     "@mantine/spotlight": "8.2.3",
     "@monaco-editor/react": "4.7.0",
-    "@pondpilot/flowscope-core": "0.4.2",
+    "@pondpilot/flowscope-core": "0.7.0",
     "@tabler/icons-react": "3.44.0",
     "@tanstack/react-table": "8.21.3",
     "allotment": "1.20.5",

--- a/src/features/editor/monaco-setup.ts
+++ b/src/features/editor/monaco-setup.ts
@@ -5,6 +5,7 @@ import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js';
 import 'monaco-editor/esm/vs/editor/browser/widget/diffEditor/diffEditor.contribution.js';
 import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching.js';
 import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js';
+import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionContributions.js';
 import 'monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js';
 import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js';
 import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';

--- a/src/features/editor/sql-editor.tsx
+++ b/src/features/editor/sql-editor.tsx
@@ -8,7 +8,7 @@ import { formatSQLInEditor } from '@controllers/sql-formatter';
 import { useEditorPreferences } from '@hooks/use-editor-preferences';
 import MonacoEditor from '@monaco-editor/react';
 import type { CompletionItemsResult, Issue, LintConfig, Span } from '@pondpilot/flowscope-core';
-import { applyEdits } from '@pondpilot/flowscope-core';
+import { applyEdits, edgesInStatement, nodesInStatement } from '@pondpilot/flowscope-core';
 import { useAppStore } from '@store/app-store';
 import { getEditorPreferences, updateEditorPreference } from '@store/editor-preferences';
 import { safeSliceBySpan, isSpanValid, type Utf16Span } from '@utils/editor/spans';
@@ -481,7 +481,9 @@ function hasCteWithLabel(
 ): boolean {
   const targetLabel = label.toLowerCase();
   return analysis.statements.some((stmt) =>
-    stmt.nodes.some((node) => node.type === 'cte' && node.label.toLowerCase() === targetLabel),
+    nodesInStatement(analysis, stmt.statementIndex).some(
+      (node) => node.type === 'cte' && node.label.toLowerCase() === targetLabel,
+    ),
   );
 }
 
@@ -989,7 +991,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
         const decorations: monaco.editor.IModelDeltaDecoration[] = [];
         analysis.statements.forEach((statement) => {
-          statement.nodes.forEach((node) => {
+          nodesInStatement(analysis, statement.statementIndex).forEach((node) => {
             if (
               !node.span ||
               (node.type !== 'table' && node.type !== 'view' && node.type !== 'cte')
@@ -1296,6 +1298,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
             // Schedule full re-split in background (for accuracy, with long debounce)
             scheduleStatementSplit(editorModel);
+            scheduleFullAnalysis(editorModel);
           }
         }),
       );
@@ -1558,7 +1561,10 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
             const [statement] = statementResult.analysis.statements;
             if (!statement) return null;
 
-            const matchingNode = statement.nodes.find((node) => {
+            const matchingNode = nodesInStatement(
+              statementResult.analysis,
+              statement.statementIndex,
+            ).find((node) => {
               if (node.type === 'column') return false;
               return node.label.toLowerCase() === word.word.toLowerCase();
             });
@@ -1569,11 +1575,15 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
             if (matchingNode.qualifiedName && matchingNode.qualifiedName !== matchingNode.label) {
               contents.push(`\n*${matchingNode.qualifiedName}*`);
             }
-            if (matchingNode.joinType) {
-              contents.push(`\n**Join:** ${matchingNode.joinType}`);
+            const matchingJoin = edgesInStatement(
+              statementResult.analysis,
+              statement.statementIndex,
+            ).find((edge) => edge.from === matchingNode.id && edge.joinType);
+            if (matchingJoin?.joinType) {
+              contents.push(`\n**Join:** ${matchingJoin.joinType}`);
             }
-            if (matchingNode.joinCondition) {
-              contents.push(`\n\`\`\`sql\nON ${matchingNode.joinCondition}\n\`\`\``);
+            if (matchingJoin?.joinCondition) {
+              contents.push(`\n\`\`\`sql\nON ${matchingJoin.joinCondition}\n\`\`\``);
             }
             if (matchingNode.filters?.length) {
               const filters = matchingNode.filters
@@ -1725,7 +1735,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
               // Find the first CTE definition with this label (first occurrence is the definition)
               for (const statement of analysis.statements) {
-                for (const node of statement.nodes) {
+                for (const node of nodesInStatement(analysis, statement.statementIndex)) {
                   if (node.type === 'cte' && node.label.toLowerCase() === targetLabel) {
                     const range = spanToRange(model, node.span);
                     if (!range) {
@@ -1765,7 +1775,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
               // Find all nodes matching the label (tables, CTEs, views)
               for (const statement of analysis.statements) {
-                for (const node of statement.nodes) {
+                for (const node of nodesInStatement(analysis, statement.statementIndex)) {
                   if (
                     (node.type === 'table' || node.type === 'cte' || node.type === 'view') &&
                     node.label.toLowerCase() === targetLabel
@@ -1967,7 +1977,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
             // Find all occurrences with spans
             for (const statement of analysis.statements) {
-              for (const node of statement.nodes) {
+              for (const node of nodesInStatement(analysis, statement.statementIndex)) {
                 if (
                   (node.type === 'table' || node.type === 'cte') &&
                   node.label.toLowerCase() === targetLabel
@@ -2029,7 +2039,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
             const ctesWithoutSpan: string[] = [];
 
             for (const statement of analysis.statements) {
-              for (const node of statement.nodes) {
+              for (const node of nodesInStatement(analysis, statement.statementIndex)) {
                 if (node.type === 'cte') {
                   const label = node.label.toLowerCase();
                   const count = cteReferences.get(label) || 0;
@@ -2110,7 +2120,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
               // Check if this is a CTE, table, or view
               const isLinkedIdentifier = analysis.statements.some((stmt) =>
-                stmt.nodes.some(
+                nodesInStatement(analysis, stmt.statementIndex).some(
                   (node) =>
                     (node.type === 'cte' || node.type === 'table' || node.type === 'view') &&
                     node.label.toLowerCase() === targetLabel,
@@ -2121,7 +2131,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
 
               // Find all occurrences with spans
               for (const statement of analysis.statements) {
-                for (const node of statement.nodes) {
+                for (const node of nodesInStatement(analysis, statement.statementIndex)) {
                   if (
                     (node.type === 'table' || node.type === 'cte' || node.type === 'view') &&
                     node.label.toLowerCase() === targetLabel
@@ -2215,23 +2225,29 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
             );
             if (allFixable.length > 1) {
               const allEdits = collectAllFixEdits(cached.result.issues);
-              const fixedText = applyEdits(sqlText, allEdits);
-              actions.push({
-                title: `Fix all lint issues (${allFixable.length})`,
-                kind: 'quickfix',
-                edit: {
-                  edits: [
-                    {
-                      resource: model.uri,
-                      versionId: undefined,
-                      textEdit: {
-                        range: model.getFullModelRange(),
-                        text: fixedText,
+              try {
+                const fixedText = applyEdits(sqlText, allEdits);
+                actions.push({
+                  title: `Fix all lint issues (${allFixable.length})`,
+                  kind: 'quickfix',
+                  edit: {
+                    edits: [
+                      {
+                        resource: model.uri,
+                        versionId: undefined,
+                        textEdit: {
+                          range: model.getFullModelRange(),
+                          text: fixedText,
+                        },
                       },
-                    },
-                  ],
-                },
-              });
+                    ],
+                  },
+                });
+              } catch (error) {
+                if (!(error instanceof Error && error.message.startsWith('Overlapping edits:'))) {
+                  throw error;
+                }
+              }
             }
 
             return { actions, dispose() {} };

--- a/tests/unit/__mocks__/flowscope-client.ts
+++ b/tests/unit/__mocks__/flowscope-client.ts
@@ -1,5 +1,11 @@
 type MockFlowScopeClient = {
-  analyze: () => Promise<Record<string, unknown>>;
+  analyze: () => Promise<{
+    statements: Array<unknown>;
+    nodes: Array<unknown>;
+    edges: Array<unknown>;
+    issues: Array<unknown>;
+    summary: { statementCount: number; hasErrors: boolean };
+  }>;
   split: (sql: string) => Promise<{ statements: Array<{ start: number; end: number }> }>;
   completionItems: () => Promise<Record<string, unknown>>;
 };
@@ -20,7 +26,13 @@ const splitBySemicolon = (sql: string): Array<{ start: number; end: number }> =>
 };
 
 const createMockFlowScopeClient = (): MockFlowScopeClient => ({
-  analyze: async () => ({}),
+  analyze: async () => ({
+    statements: [],
+    nodes: [],
+    edges: [],
+    issues: [],
+    summary: { statementCount: 0, hasErrors: false },
+  }),
   split: async (sql: string) => ({ statements: splitBySemicolon(sql) }),
   completionItems: async () => ({}),
 });

--- a/tests/unit/__mocks__/flowscope-core.ts
+++ b/tests/unit/__mocks__/flowscope-core.ts
@@ -1,5 +1,8 @@
 type AnalyzeResult = {
   statements: Array<unknown>;
+  nodes: Array<{ statementIds?: number[] }>;
+  edges: Array<{ statementIds?: number[] }>;
+  issues: Array<unknown>;
   summary: {
     statementCount: number;
     hasErrors: boolean;
@@ -8,6 +11,9 @@ type AnalyzeResult = {
 
 export const analyzeSql = async (): Promise<AnalyzeResult> => ({
   statements: [],
+  nodes: [],
+  edges: [],
+  issues: [],
   summary: {
     statementCount: 0,
     hasErrors: false,
@@ -15,3 +21,15 @@ export const analyzeSql = async (): Promise<AnalyzeResult> => ({
 });
 
 export const initWasm = async (): Promise<void> => {};
+
+export const nodesInStatement = (
+  result: AnalyzeResult,
+  statementIndex: number,
+): AnalyzeResult['nodes'] =>
+  result.nodes.filter((node) => node.statementIds?.includes(statementIndex));
+
+export const edgesInStatement = (
+  result: AnalyzeResult,
+  statementIndex: number,
+): AnalyzeResult['edges'] =>
+  result.edges.filter((edge) => edge.statementIds?.includes(statementIndex));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,10 +3095,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pondpilot/flowscope-core@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@pondpilot/flowscope-core@npm:0.4.2"
-  checksum: 10c0/856686bd0448774153f68745f23c049be053eb88be94c820ff80eea0539092851c65a6ffb41ce7b57363f97f6cf6b24f06cdb897db924d69415184e9c18defef
+"@pondpilot/flowscope-core@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@pondpilot/flowscope-core@npm:0.7.0"
+  checksum: 10c0/b393f8f255c73cf23bd17f8ee2aed59af4383ae59f10b4bf966da0f08213af939995cb9df0e98e45fa7bd8eddbaa0d5fc3381b416e601674029305286a03e374
   languageName: node
   linkType: hard
 
@@ -10769,7 +10769,7 @@ __metadata:
     "@mantine/spotlight": "npm:8.2.3"
     "@monaco-editor/react": "npm:4.7.0"
     "@playwright/test": "npm:1.61.1"
-    "@pondpilot/flowscope-core": "npm:0.4.2"
+    "@pondpilot/flowscope-core": "npm:0.7.0"
     "@tabler/icons-react": "npm:3.44.0"
     "@tanstack/eslint-plugin-query": "npm:5.101.2"
     "@tanstack/react-table": "npm:8.21.3"


### PR DESCRIPTION
Tier 3 of the dependency stabilization (after #320/#321) — the editor layer.

## FlowScope 0.4.2 → 0.7.0
PondPilot's own SQL analysis engine. API migration: statement node/edge access moved to `nodesInStatement`/`edgesInStatement` helpers; jest mocks updated. **In-browser verification with screenshots**: schema-aware autocomplete, folding, live lint while typing, `= NULL` → `IS NULL` quick-fix, per-tab `USE` isolation (all six per-tab-session tests), end-to-end query. FlowScope WASM +2.3% (8.71→8.91 MB).

## Regression found & fixed: lint quick-fixes were broken
The Monaco explicit-import trim (#319) silently dropped the `codeAction` contribution — its verification checklist covered find/fold/complete/context-menu but **not quick-fixes**. Restored, verified with before/after screenshots.

## Monaco stays pinned at 0.52.2 (deliberate)
0.55.1 was evaluated: it regresses the monaco chunk **2.94 → 3.73 MB (+27%)** with the same trimmed import set and offers nothing the app needs. It joins `@duckdb/duckdb-wasm` and `apache-arrow` as a documented engineering pin; revisit if a needed feature/fix ships.

## Gates (all exit 0)
typecheck · unit+coverage (1177) · eslint 0 errors · prettier · build + bundle budget (6.18 MB) · script+spotlight Playwright (31 passed) · `yarn install --immutable`