### PR TITLE
chore(deps): migrate react-router-dom 6 to react-router 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-icons": "5.7.0",
     "react-is": "19.2.7",
     "react-markdown": "10.1.0",
-    "react-router-dom": "6.30.0",
+    "react-router": "7.18.1",
     "reactflow": "11.11.4",
     "recharts": "3.9.2",
     "sql-formatter": "15.8.2",

--- a/src/components/error-fallback/views/app-error-fallback.tsx
+++ b/src/components/error-fallback/views/app-error-fallback.tsx
@@ -5,7 +5,7 @@ import { APP_SUPPORT_URL } from '@models/app-urls';
 import { IconCircleCheck, IconRefresh, IconDownload, IconTrash } from '@tabler/icons-react';
 import { setDataTestId } from '@utils/test-id';
 import { useState } from 'react';
-import { useRouteError } from 'react-router-dom';
+import { useRouteError } from 'react-router';
 
 import { deleteApplicationData } from '../utils';
 

--- a/src/components/layout/components/header.tsx
+++ b/src/components/layout/components/header.tsx
@@ -13,7 +13,7 @@ import { IconSearch } from '@tabler/icons-react';
 import { setDataTestId } from '@utils/test-id';
 import { cn } from '@utils/ui/styles';
 import { memo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 export const Header = memo(() => {
   const navigate = useNavigate();

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -2,7 +2,7 @@ import { DesktopOnly } from '@components/desktop-only';
 import { DndOverlay } from '@components/dnd-overlay';
 import { useAddLocalFilesOrFolders } from '@hooks/use-add-local-files-folders';
 import { Stack } from '@mantine/core';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { Header } from './components/header';
 

--- a/src/components/spotlight/spotlight.tsx
+++ b/src/components/spotlight/spotlight.tsx
@@ -59,7 +59,7 @@ import {
 } from '@utils/table-access';
 import { setDataTestId } from '@utils/test-id';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { SpotlightBreadcrumbs } from './components';
 import { renderActionsGroup } from './components/action';

--- a/src/features/script-import/shared-script-import.tsx
+++ b/src/features/script-import/shared-script-import.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '@store/app-store';
 import { importScript, validateEncodedScript } from '@utils/script-import-utils';
 import { SharedScript } from '@utils/script-sharing';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 /**
  * Component that handles importing a shared script from URL.

--- a/src/hooks/use-global-navigation.ts
+++ b/src/hooks/use-global-navigation.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 /**
  * Hook that listens for global navigation events and handles programmatic navigation.

--- a/src/pages/main-page/components/accordion-navbar.tsx
+++ b/src/pages/main-page/components/accordion-navbar.tsx
@@ -12,7 +12,7 @@ import {
   IconBug,
 } from '@tabler/icons-react';
 import { setDataTestId } from '@utils/test-id';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { AccordionContent } from './accordion-content';
 import { BottomToolbar } from './bottom-toolbar';

--- a/src/pages/main-page/components/bottom-toolbar.tsx
+++ b/src/pages/main-page/components/bottom-toolbar.tsx
@@ -9,7 +9,7 @@ import {
   IconBug,
 } from '@tabler/icons-react';
 import { setDataTestId } from '@utils/test-id';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 interface BottomToolbarProps {
   onCollapse?: () => void;

--- a/src/pages/settings-page/settings-page.tsx
+++ b/src/pages/settings-page/settings-page.tsx
@@ -3,7 +3,7 @@ import { ActionIcon, Divider, Stack } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { setDataTestId } from '@utils/test-id';
 import { Fragment, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { SettingsBlock } from './components/settings-block';
 import { SettingsNavigation } from './components/settings-navigation';

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -8,7 +8,7 @@ import { SharedScriptImport } from '@features/script-import';
 import { useTabCoordinationContext } from '@features/tab-coordination-context';
 import { MainPage } from '@pages/main-page';
 import { SettingsPage } from '@pages/settings-page';
-import { createBrowserRouter, RouterProvider, Navigate, RouteObject } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate, RouteObject } from 'react-router';
 
 let devOnlyRoutes: RouteObject[] = [];
 
@@ -84,19 +84,8 @@ export function Router() {
         ],
       },
     ],
-    {
-      basename: import.meta.env.BASE_URL,
-      future: {
-        // These flags go on createBrowserRouter
-        v7_relativeSplatPath: true,
-        v7_fetcherPersist: true,
-        v7_normalizeFormMethod: true,
-        v7_partialHydration: true,
-        v7_skipActionErrorRevalidation: true,
-      },
-    },
+    { basename: import.meta.env.BASE_URL },
   );
 
-  // v7_startTransition goes on RouterProvider, not createBrowserRouter
-  return <RouterProvider router={router} future={{ v7_startTransition: true }} />;
+  return <RouterProvider router={router} />;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,13 +3247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@remix-run/router@npm:1.23.0"
-  checksum: 10c0/eaef5cb46a1e413f7d1019a75990808307e08e53a39d4cf69c339432ddc03143d725decef3d6b9b5071b898da07f72a4a57c4e73f787005fcf10162973d8d7d7
-  languageName: node
-  linkType: hard
-
 "@rollup/plugin-babel@npm:^5.2.0":
   version: 5.3.1
   resolution: "@rollup/plugin-babel@npm:5.3.1"
@@ -5793,7 +5786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.0.2":
+"cookie@npm:^1.0.1, cookie@npm:^1.0.2":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
@@ -10816,7 +10809,7 @@ __metadata:
     react-icons: "npm:5.7.0"
     react-is: "npm:19.2.7"
     react-markdown: "npm:10.1.0"
-    react-router-dom: "npm:6.30.0"
+    react-router: "npm:7.18.1"
     reactflow: "npm:11.11.4"
     recharts: "npm:3.9.2"
     sql-formatter: "npm:15.8.2"
@@ -11336,27 +11329,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.30.0":
-  version: 6.30.0
-  resolution: "react-router-dom@npm:6.30.0"
+"react-router@npm:7.18.1":
+  version: 7.18.1
+  resolution: "react-router@npm:7.18.1"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.0"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/262954ba894d6a241ceda5f61098f7d6a292d0018a6ebb9c9c67425b7deb6e59b6191a9233a03d38e287e60f7ac3702e9e84c8e20b39a6487698fe088b71e27a
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.0":
-  version: 6.30.0
-  resolution: "react-router@npm:6.30.0"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/e6f20cf5c47ec057a057a4cfb9a55983d0a5b4b3314d20e07f0a70e59e004f51778d4dac415aee1e4e64db69cc4cd72e5acf8fd60dcf07d909895b8863b0b023
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
   languageName: node
   linkType: hard
 
@@ -11994,6 +11979,13 @@ __metadata:
   version: 7.0.5
   resolution: "serialize-javascript@npm:7.0.5"
   checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tier 4 of the dependency stabilization (after #320–#322).

`react-router-dom` 6.30.0 → `react-router` **7.18.1** (v7's consolidated package), pinned exact. The migration was gentle because the app had already opted into every v7 future flag — they're now defaults and simply removed. `basename` (subdirectory deployment support per DEPLOYMENT.md) preserved and verified in the diff.

## Browser verification (real chromium against the built app)
cold boot · settings navigation · browser back/forward · direct deep links (`/settings`, `/shared-script/:encodedScript` incl. import+redirect) · `/error-test` fallback · unknown-path redirect → `/`

## Gates (all exit 0)
typecheck · unit+coverage (1177) · eslint 0 errors · prettier · build + bundle budget (6.21 MB) · routing-adjacent Playwright (script/onboarding/settings/shared-script/error-fallback, 36 passed) · `yarn install --immutable`