### PR TITLE
perf(startup): hydrate local database metadata after app-ready

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default [
   },
   {
     ignores: [
+      '.module-cache/**',
       '**/*.cjs',
       '**/*.d.ts',
       '**/*.d.mts',

--- a/src/controllers/db/duckdb-meta.ts
+++ b/src/controllers/db/duckdb-meta.ts
@@ -69,6 +69,33 @@ export async function getViews(
   return queryOneColumn<arrow.Utf8>(conn, sql, 'view_name');
 }
 
+/**
+ * Check whether a database schema contains any user tables or views without
+ * loading their column metadata.
+ */
+export async function hasDatabaseObjects(
+  conn: AsyncDuckDBConnectionPool,
+  databaseName: string,
+  schemaName: string,
+): Promise<boolean> {
+  const sql = `
+    SELECT EXISTS (
+      SELECT 1
+      FROM duckdb_tables
+      WHERE database_name = ${quote(databaseName, { single: true })}
+        AND schema_name = ${quote(schemaName, { single: true })}
+      UNION ALL
+      SELECT 1
+      FROM duckdb_views
+      WHERE database_name = ${quote(databaseName, { single: true })}
+        AND schema_name = ${quote(schemaName, { single: true })}
+    ) AS has_objects
+  `;
+
+  const result = await conn.query<{ has_objects: arrow.Bool }>(sql);
+  return result.getChild('has_objects')?.get(0) ?? false;
+}
+
 function buildColumnsQueryWithFilters(
   databaseNames?: string[],
   schemaNames?: string[],

--- a/src/features/app-context/hooks/use-init-application.tsx
+++ b/src/features/app-context/hooks/use-init-application.tsx
@@ -2,6 +2,7 @@ import { showError, showWarning } from '@components/app-notifications';
 import { installCorsProxyMacros } from '@controllers/db/cors-proxy-macros-controller';
 import { loadDuckDBFunctions } from '@controllers/db/duckdb-functions-controller';
 import { getDatabaseModel } from '@controllers/db/duckdb-meta';
+import { refreshDatabaseMetadata } from '@features/data-explorer/utils/metadata-refresh';
 import {
   useDuckDBConnectionPool,
   useDuckDBInitializer,
@@ -16,6 +17,7 @@ import {
   isRemoteDatabase,
   isIcebergCatalog,
   isDuckLakeCatalog,
+  isLocalDatabase,
   isMotherDuckConnection,
   isQuackConnection,
 } from '@utils/data-source';
@@ -285,6 +287,15 @@ export function useAppInitialization({
       setAppLoadState('ready');
 
       (async () => {
+        // Local sources are ready for queries as soon as restore completes.
+        // Hydrate their full table/column metadata in the background so it does
+        // not delay the app's ready state. Remote metadata remains owned by the
+        // reconnect flow below.
+        const localDatabaseNames = Array.from(useAppStore.getState().dataSources.values())
+          .filter(isLocalDatabase)
+          .map((dataSource) => dataSource.dbName);
+        void refreshDatabaseMetadata(resolvedConn, [...new Set(localDatabaseNames)]);
+
         try {
           // Load DuckDB functions into the store
           await loadDuckDBFunctions(resolvedConn);

--- a/src/store/restore.ts
+++ b/src/store/restore.ts
@@ -6,7 +6,7 @@ import {
   createXlsxSheetView,
   dropViewAndUnregisterFile,
 } from '@controllers/db/data-source';
-import { getDatabaseModel } from '@controllers/db/duckdb-meta';
+import { hasDatabaseObjects } from '@controllers/db/duckdb-meta';
 import { persistAddLocalEntry } from '@controllers/file-system/persist';
 import { persistDeleteTab } from '@controllers/tab/persist';
 import { deleteTabImpl } from '@controllers/tab/pure';
@@ -22,6 +22,7 @@ import {
   SYSTEM_DATABASE_NAME,
   SYSTEM_DATABASE_FILE_SOURCE_ID,
 } from '@models/data-source';
+import { DataBaseModel } from '@models/db';
 import {
   ignoredFolders,
   LocalEntry,
@@ -1090,8 +1091,11 @@ export const restoreAppDataFromIDB = async (
     await persistDeleteTab(iDbConn, tabsToDelete, newActiveTabId, newPreviewTabId, newTabOrder);
   }
 
-  // Read database meta data
-  const databaseMetadata = await getDatabaseModel(conn);
+  // Restored script results that reference the system database are only valid
+  // when that database still has objects. Check that without loading full
+  // column metadata, which is hydrated after the app becomes ready.
+  const systemDatabaseHasObjects = await hasDatabaseObjects(conn, SYSTEM_DATABASE_NAME, 'main');
+  const databaseMetadata = new Map<string, DataBaseModel>();
 
   // Always add the PondPilot system database to dataSources
   // This ensures it's visible even when empty on fresh start
@@ -1126,7 +1130,7 @@ export const restoreAppDataFromIDB = async (
         return [tabId, tab];
       }
 
-      if (!shouldResetRestoredScriptQuery(tab.lastExecutedQuery, databaseMetadata)) {
+      if (!shouldResetRestoredScriptQuery(tab.lastExecutedQuery, !systemDatabaseHasObjects)) {
         return [tabId, tab];
       }
 

--- a/src/utils/script-query-persistence.ts
+++ b/src/utils/script-query-persistence.ts
@@ -16,14 +16,11 @@ export function isSystemDatabaseEmpty(databaseMetadata: Map<string, DataBaseMode
 
 export function shouldResetRestoredScriptQuery(
   lastExecutedQuery: string | null,
-  databaseMetadata: Map<string, DataBaseModel>,
+  systemDatabaseIsEmpty: boolean,
 ): boolean {
   if (!lastExecutedQuery) {
     return false;
   }
 
-  return (
-    isSystemDatabaseEmpty(databaseMetadata) &&
-    systemDatabaseReferencePattern.test(lastExecutedQuery)
-  );
+  return systemDatabaseIsEmpty && systemDatabaseReferencePattern.test(lastExecutedQuery);
 }

--- a/tests/integration/data-explorer/startup-metadata.spec.ts
+++ b/tests/integration/data-explorer/startup-metadata.spec.ts
@@ -1,0 +1,125 @@
+import { expect, mergeTests } from '@playwright/test';
+
+import { test as dataViewTest } from '../fixtures/data-view';
+import { test as dbExplorerTest } from '../fixtures/db-explorer';
+import { test as filePickerTest } from '../fixtures/file-picker';
+import { test as fileSystemExplorerTest } from '../fixtures/file-system-explorer';
+import { test as baseTest } from '../fixtures/page';
+import { test as spotlightTest } from '../fixtures/spotlight';
+import { test as waitUtilsTest } from '../fixtures/wait-utils';
+import { FileSystemNode } from '../models';
+
+const test = mergeTests(
+  baseTest,
+  filePickerTest,
+  fileSystemExplorerTest,
+  dbExplorerTest,
+  dataViewTest,
+  spotlightTest,
+  waitUtilsTest,
+);
+
+const restoredSources: FileSystemNode[] = [
+  {
+    type: 'file',
+    ext: 'csv',
+    name: 'startup_alpha',
+    content: 'id,label\n1,alpha\n2,beta',
+  },
+  {
+    type: 'file',
+    ext: 'csv',
+    name: 'startup_beta',
+    content: 'id,value\n1,10\n2,20',
+  },
+  {
+    type: 'file',
+    ext: 'csv',
+    name: 'startup_gamma',
+    content: 'id,enabled\n1,true\n2,false',
+  },
+  {
+    type: 'file',
+    ext: 'duckdb',
+    name: 'startup_database',
+    content:
+      "CREATE TABLE startup_table (id INTEGER, description VARCHAR); INSERT INTO startup_table VALUES (1, 'restored');",
+  },
+];
+
+test('hydrates restored local metadata after ready without blocking source use', async ({
+  page,
+  setupFileSystem,
+  waitForFilesToBeProcessed,
+  reloadPage,
+  assertFileExplorerItems,
+  assertDBExplorerItems,
+  openFileFromExplorer,
+  assertDataTableMatches,
+  getDBNodeByName,
+  openSpotlight,
+}) => {
+  await setupFileSystem(restoredSources);
+  await waitForFilesToBeProcessed();
+
+  await reloadPage();
+
+  await expect(page.getByTestId('app-state')).toHaveAttribute('data-app-load-state', 'ready');
+  await assertFileExplorerItems(['startup_alpha', 'startup_beta', 'startup_gamma']);
+  await assertDBExplorerItems(['startup_database']);
+
+  // Views are queryable as soon as restore reports ready, independent of the
+  // background metadata refresh.
+  await openFileFromExplorer('startup_alpha');
+  await assertDataTableMatches({
+    data: [
+      ['1', 'alpha'],
+      ['2', 'beta'],
+    ],
+    columnNames: ['id', 'label'],
+  });
+
+  // The attached database gains its schema, table, and columns when the
+  // background metadata snapshot merges into the store.
+  await (await getDBNodeByName('startup_database')).click();
+  await (await getDBNodeByName('main')).click();
+  const tableNode = await getDBNodeByName('startup_table');
+  await expect(tableNode).toBeVisible();
+  await tableNode.click();
+  await assertDataTableMatches({
+    data: [['1', 'restored']],
+    columnNames: ['id', 'description'],
+  });
+
+  // Spotlight receives the same merged table metadata.
+  const spotlight = await openSpotlight();
+  await page.getByTestId('spotlight-search').fill('startup_table');
+  await expect(spotlight.getByText('startup_table', { exact: true })).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // Comparison source selection reads metadata-backed attached tables and
+  // remains able to select flat-file sources.
+  const comparisonSpotlight = await openSpotlight();
+  await comparisonSpotlight.getByTestId('spotlight-action-create-new-comparison').click();
+
+  const sourceButtons = page.getByRole('button', { name: 'Not selected', exact: true });
+  await sourceButtons.nth(0).click();
+  await page.getByTestId('spotlight-search').fill('startup_table');
+  await page.getByTestId('spotlight-menu').getByText('startup_table', { exact: true }).click();
+
+  await sourceButtons.nth(0).click();
+  await page.getByTestId('spotlight-search').fill('startup_alpha');
+  await page.getByTestId('spotlight-menu').getByText('startup_alpha', { exact: true }).click();
+
+  await expect(
+    page
+      .getByRole('button', {
+        name: 'startup_database.main.startup_table',
+        exact: true,
+      })
+      .last(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'pondpilot.main.startup_alpha', exact: true }),
+  ).toBeVisible();
+});

--- a/tests/unit/controllers/db/duckdb-meta.test.ts
+++ b/tests/unit/controllers/db/duckdb-meta.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { hasDatabaseObjects } from '../../../../src/controllers/db/duckdb-meta';
+import { AsyncDuckDBConnectionPool } from '../../../../src/services/duckdb-pool/duckdb-connection-pool';
+
+describe('hasDatabaseObjects', () => {
+  it.each([true, false])('returns %s from the lightweight catalog query', async (hasObjects) => {
+    const get = jest.fn(() => hasObjects);
+    const query = jest.fn(async (_sql: string) => ({
+      getChild: jest.fn(() => ({ get })),
+    }));
+    const conn = { query } as unknown as AsyncDuckDBConnectionPool;
+
+    await expect(hasDatabaseObjects(conn, 'pondpilot', 'main')).resolves.toBe(hasObjects);
+
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('FROM duckdb_tables');
+    expect(sql).toContain('FROM duckdb_views');
+    expect(sql).toContain("database_name = 'pondpilot'");
+    expect(sql).toContain("schema_name = 'main'");
+    expect(sql).not.toContain('duckdb_columns');
+  });
+
+  it('treats a missing result column as empty', async () => {
+    const conn = {
+      query: jest.fn(async () => ({ getChild: jest.fn(() => null) })),
+    } as unknown as AsyncDuckDBConnectionPool;
+
+    await expect(hasDatabaseObjects(conn, 'pondpilot', 'main')).resolves.toBe(false);
+  });
+});

--- a/tests/unit/utils/script-query-persistence.test.ts
+++ b/tests/unit/utils/script-query-persistence.test.ts
@@ -37,7 +37,10 @@ describe('script-query-persistence', () => {
     const metadata = buildMetadata(['store_purchases']);
 
     expect(
-      shouldResetRestoredScriptQuery('SELECT * FROM pondpilot.main.store_purchases', metadata),
+      shouldResetRestoredScriptQuery(
+        'SELECT * FROM pondpilot.main.store_purchases',
+        isSystemDatabaseEmpty(metadata),
+      ),
     ).toBe(false);
   });
 
@@ -47,7 +50,7 @@ describe('script-query-persistence', () => {
     expect(
       shouldResetRestoredScriptQuery(
         'SELECT account_id FROM pondpilot.main.store_purchases',
-        metadata,
+        isSystemDatabaseEmpty(metadata),
       ),
     ).toBe(true);
   });
@@ -55,9 +58,12 @@ describe('script-query-persistence', () => {
   it('does not reset unrelated restored queries when the system database is empty', () => {
     const metadata = buildMetadata([]);
 
-    expect(shouldResetRestoredScriptQuery('SELECT 1', metadata)).toBe(false);
+    expect(shouldResetRestoredScriptQuery('SELECT 1', isSystemDatabaseEmpty(metadata))).toBe(false);
     expect(
-      shouldResetRestoredScriptQuery('SELECT * FROM motherduck.main.store_purchases', metadata),
+      shouldResetRestoredScriptQuery(
+        'SELECT * FROM motherduck.main.store_purchases',
+        isSystemDatabaseEmpty(metadata),
+      ),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
Stage 2 of the startup plan (after #318). The boot-path analysis flagged `getDatabaseModel(conn)` — a full `duckdb_columns × duckdb_tables` scan over **all** attached local databases — as the last big awaited cost inside restore before `appLoadState='ready'`.

## Change
- Restore's only true metadata need at boot is the system-db check for resetting restored script results → new `hasDatabaseObjects` EXISTS probe (no column scan).
- Full local metadata hydrates in the existing Stage-1 background block via `refreshDatabaseMetadata` (its own error handling; functional-merge into the store). Remote metadata unchanged (reconnect flow owns it).

## Hazards verified empirically (from the boot analysis)
- Explorer renders sources with absent metadata and fills in tables/columns as hydration lands (restored-sources flow driven in a real browser; new `startup-metadata.spec.ts` pins it)
- Spotlight tolerates partial metadata; comparison pickers work post-hydration
- Affected suites (data-explorer, db-explorer, comparison, script, spotlight): **53 passed**

## Gates
typecheck · unit+coverage (1180 tests, 82.06% branches) · eslint 0 errors · prettier · build + budget · `--immutable` — all exit 0