### PR TITLE
perf(startup): publish interactive scripts before DuckDB readiness

### DIFF
--- a/src/features/app-context/hooks/use-init-application.tsx
+++ b/src/features/app-context/hooks/use-init-application.tsx
@@ -10,7 +10,11 @@ import {
 import { AnyDataSource } from '@models/data-source';
 import { AsyncDuckDBConnectionPool } from '@services/duckdb-pool/duckdb-connection-pool';
 import { useAppStore, setAppLoadState } from '@store/app-store';
-import { restoreAppDataFromIDB } from '@store/restore';
+import {
+  CoreAppDataSnapshot,
+  restoreAppDataFromIDB,
+  restoreCoreAppDataFromIDB,
+} from '@store/restore';
 import { MaxRetriesExceededError } from '@utils/connection-errors';
 import { attachDatabaseWithRetry } from '@utils/connection-manager';
 import {
@@ -43,7 +47,7 @@ import {
 import { updateRemoteDbConnectionState } from '@utils/remote-database';
 import { sanitizeErrorMessage } from '@utils/sanitize-error';
 import { buildAttachQuery } from '@utils/sql-builder';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useShowPermsAlert } from './use-show-perm-alert';
 
@@ -274,14 +278,24 @@ export function useAppInitialization({
 
   const conn = useDuckDBConnectionPool();
   const connectDuckDb = useDuckDBInitializer();
+  const initializationRunRef = useRef<Promise<void> | null>(null);
+  const initializationGenerationRef = useRef(0);
 
-  const initAppData = async (resolvedConn: AsyncDuckDBConnectionPool) => {
+  const initAppData = async (
+    resolvedConn: AsyncDuckDBConnectionPool,
+    coreSnapshot: CoreAppDataSnapshot,
+    generation: number,
+  ) => {
     // Init app db (state persistence)
     // TODO: handle errors, e.g. blocking on older version from other tab
     try {
-      const { discardedEntries, warnings } = await restoreAppDataFromIDB(resolvedConn, (_) =>
-        showPermsAlert(),
+      const { discardedEntries, warnings } = await restoreAppDataFromIDB(
+        resolvedConn,
+        (_) => showPermsAlert(),
+        coreSnapshot,
       );
+
+      if (generation !== initializationGenerationRef.current) return;
 
       // Report we're ready for user interactions now.
       setAppLoadState('ready');
@@ -383,18 +397,22 @@ export function useAppInitialization({
         });
       }
     } catch (error) {
+      if (generation !== initializationGenerationRef.current) return;
       const message = error instanceof Error ? error.message : String(error);
       console.error('Error restoring app data:', message);
       showError({
         title: 'Cannot restore app data',
         message: `Failed to restore app data. ${message}`,
       });
+      setAppLoadState('error');
     }
   };
 
   useEffect(() => {
     // Don't initialize DuckDB if this tab is blocked by another active tab
     if (isTabBlocked) {
+      initializationGenerationRef.current += 1;
+      initializationRunRef.current = null;
       setAppLoadState('init');
       return;
     }
@@ -403,17 +421,56 @@ export function useAppInitialization({
     // we are not initializing either in-memory DuckDB or the app data.
     if (!isFileAccessApiSupported || isMobileDevice) return;
 
-    if (useAppStore.getState().appLoadState === 'ready') {
+    if (useAppStore.getState().appLoadState === 'ready' || initializationRunRef.current) {
       return;
     }
 
-    // Start initialization of data when the database is ready
-    if (conn) {
-      setAppLoadState('init');
-      initAppData(conn);
-    } else {
-      setAppLoadState('init');
-      connectDuckDb();
-    }
-  }, [conn, isTabBlocked]);
+    const generation = ++initializationGenerationRef.current;
+    setAppLoadState('init');
+
+    const initializationRun = (async () => {
+      // Start the independent IDB read and DuckDB boot together. Core hydration
+      // publishes scripts first; the full restore waits for both dependencies.
+      const coreRestorePromise = restoreCoreAppDataFromIDB();
+      const connectionPromise = conn ? Promise.resolve(conn) : connectDuckDb();
+
+      try {
+        const coreSnapshot = await coreRestorePromise;
+        if (generation !== initializationGenerationRef.current) return;
+        setAppLoadState('core-ready');
+
+        const resolvedConn = await connectionPromise;
+        if (generation !== initializationGenerationRef.current) return;
+        if (!resolvedConn) {
+          setAppLoadState('error');
+          showError({
+            title: 'Cannot initialize database',
+            message: 'DuckDB failed to initialize. Reload the app to try again.',
+          });
+          return;
+        }
+
+        await initAppData(resolvedConn, coreSnapshot, generation);
+      } catch (error) {
+        if (generation !== initializationGenerationRef.current) return;
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('Error initializing app data:', message);
+        showError({
+          title: 'Cannot initialize app data',
+          message: `Failed to initialize app data. ${message}`,
+        });
+        setAppLoadState('error');
+      }
+    })();
+
+    initializationRunRef.current = initializationRun;
+    initializationRun.finally(() => {
+      if (initializationRunRef.current === initializationRun) {
+        initializationRunRef.current = null;
+      }
+    });
+    // initAppData intentionally belongs to this initialization generation. Adding
+    // its render-local identity would restart an in-flight boot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conn, connectDuckDb, isFileAccessApiSupported, isMobileDevice, isTabBlocked]);
 }

--- a/src/features/script-editor/components/components/run-query-button/run-query-button.tsx
+++ b/src/features/script-editor/components/components/run-query-button/run-query-button.tsx
@@ -31,6 +31,7 @@ export const RunQueryButton = ({ disabled, onRunClick }: RunQueryButtonProps) =>
     <Button.Group>
       <Button
         onClick={() => onRunClick(defaultOption)}
+        disabled={disabled}
         className="min-w-20"
         data-testid={setDataTestId('run-query-button')}
       >
@@ -45,7 +46,10 @@ export const RunQueryButton = ({ disabled, onRunClick }: RunQueryButtonProps) =>
         disabled={disabled}
       >
         <Menu.Target>
-          <div className="bg-backgroundAccent-light dark:bg-backgroundAccent-dark rounded-r-2xl border-l border-borderLight-light dark:border-borderLight-dark flex items-center justify-center cursor-pointer pr-2 pl-1">
+          <div
+            aria-disabled={disabled}
+            className="bg-backgroundAccent-light dark:bg-backgroundAccent-dark rounded-r-2xl border-l border-borderLight-light dark:border-borderLight-dark flex items-center justify-center cursor-pointer pr-2 pl-1"
+          >
             <IconChevronDown
               size={20}
               className="text-textContrast-light dark:text-textContrast-dark"

--- a/src/features/script-editor/components/script-editor-data-state-pane.tsx
+++ b/src/features/script-editor/components/script-editor-data-state-pane.tsx
@@ -24,6 +24,7 @@ interface ScriptEditorDataStatePaneProps {
   historyMode?: boolean;
   selectedVersion?: ScriptVersion | null;
   sessionSelector?: ReactNode;
+  runDisabled?: boolean;
 
   handleRunQuery: (mode?: 'all' | 'selection') => Promise<void>;
   onAIAssistantClick: () => void;
@@ -39,6 +40,7 @@ export const ScriptEditorDataStatePane = ({
   historyMode = false,
   selectedVersion,
   sessionSelector,
+  runDisabled = false,
   handleRunQuery,
   onAIAssistantClick,
   onEnterHistoryMode,
@@ -231,7 +233,7 @@ export const ScriptEditorDataStatePane = ({
             </ActionIcon>
           </Tooltip>
         </Group>
-        <RunQueryButton disabled={running} onRunClick={handleRunQuery} />
+        <RunQueryButton disabled={running || runDisabled} onRunClick={handleRunQuery} />
       </Group>
     </Group>
   );

--- a/src/features/script-editor/script-editor.tsx
+++ b/src/features/script-editor/script-editor.tsx
@@ -85,6 +85,7 @@ interface ScriptEditorProps {
   scriptState: ScriptExecutionState;
 
   active?: boolean;
+  databaseReady?: boolean;
 
   runScriptQuery: (query: string) => Promise<void>;
 }
@@ -93,6 +94,7 @@ export const ScriptEditor = ({
   id: scriptId,
   tabId,
   active,
+  databaseReady = true,
   runScriptQuery,
   scriptState,
 }: ScriptEditorProps) => {
@@ -290,6 +292,8 @@ export const ScriptEditor = ({
   );
 
   const handleRunQuery = async (mode?: RunScriptMode) => {
+    if (!databaseReady) return;
+
     const editorHandle = editorRef.current;
     const editor = editorHandle?.editor;
     const model = editor?.getModel();
@@ -591,12 +595,15 @@ export const ScriptEditor = ({
           dirty={dirty}
           handleRunQuery={handleRunQuery}
           scriptState={scriptState}
+          runDisabled={!databaseReady}
           onAIAssistantClick={handleAIAssistantClick}
           historyMode={historyMode}
           onEnterHistoryMode={shouldShowVersionHistory ? handleEnterHistoryMode : undefined}
           onExitHistoryMode={handleExitHistoryMode}
           selectedVersion={selectedVersionForDiff}
-          sessionSelector={<ScriptSessionSelector scriptId={scriptId} tabId={tabId} />}
+          sessionSelector={
+            databaseReady ? <ScriptSessionSelector scriptId={scriptId} tabId={tabId} /> : undefined
+          }
           onRestoreVersion={handleRestoreVersion}
           onRenameVersion={handleRenameVersion}
         />

--- a/src/features/script-explorer/script-explorer.tsx
+++ b/src/features/script-explorer/script-explorer.tsx
@@ -15,7 +15,7 @@ import {
   findTabFromComparison,
   getOrCreateTabFromComparison,
 } from '@controllers/tab/comparison-tab-controller';
-import { useInitializedDuckDBConnectionPool } from '@features/duckdb-context/duckdb-context';
+import { useDuckDBConnectionPool } from '@features/duckdb-context/duckdb-context';
 import { RenderTreeNodePayload as MantineRenderTreeNodePayload } from '@mantine/core';
 import { ComparisonId } from '@models/comparison';
 import { SQLScriptId } from '@models/sql-script';
@@ -170,8 +170,13 @@ export const ScriptExplorer = memo(() => {
    * Global state
    */
   const sqlScripts = useSqlScriptNameMap();
-  const comparisons = useComparisonsList();
-  const pool = useInitializedDuckDBConnectionPool();
+  const restoredComparisons = useComparisonsList();
+  const appReady = useAppStore.use.appLoadState() === 'ready';
+  const comparisons = useMemo(
+    () => (appReady ? restoredComparisons : []),
+    [appReady, restoredComparisons],
+  );
+  const pool = useDuckDBConnectionPool();
 
   const hasActiveElement = useAppStore((state) => {
     const activeTab = state.activeTabId && state.tabs.get(state.activeTabId);
@@ -250,6 +255,7 @@ export const ScriptExplorer = memo(() => {
   const handleNodeDelete = useCallback(
     (node: TreeNodeData<ScriptNodeTypeToIdTypeMap>) => {
       if (isComparisonNode(node)) {
+        if (!pool) return;
         deleteComparisons([node.value], pool).catch(() => {
           // Ignored: error handling happens via global notifications
         });
@@ -392,6 +398,7 @@ export const ScriptExplorer = memo(() => {
         deleteSqlScripts(scriptIds);
       }
       if (comparisonIds.length > 0) {
+        if (!pool) return;
         deleteComparisons(comparisonIds, pool).catch(() => {
           // Ignored: error handling happens via global notifications
         });

--- a/src/features/tab-view/tab-view.tsx
+++ b/src/features/tab-view/tab-view.tsx
@@ -1,7 +1,9 @@
 import { deleteTab } from '@controllers/tab';
 import { ComparisonTabView } from '@features/comparison';
+import { ScriptEditor } from '@features/script-editor';
 import { Skeleton, Stack } from '@mantine/core';
-import { useAppStore, useTabTypeMap } from '@store/app-store';
+import { ScriptTab, TabId } from '@models/tab';
+import { useAppStore, useTabReactiveState, useTabTypeMap } from '@store/app-store';
 import { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -10,6 +12,22 @@ import { useTabCache } from './hooks/use-tab-cache';
 import { FileDataSourceTabView, SchemaTabView, ScriptTabView } from './views';
 
 const TAB_CACHE_SIZE = 10;
+const ignoreRunUntilDatabaseReady = async () => {};
+
+const CoreReadyScriptTabView = ({ tabId, active }: { tabId: TabId; active: boolean }) => {
+  const tab = useTabReactiveState<ScriptTab>(tabId, 'script');
+
+  return (
+    <ScriptEditor
+      id={tab.sqlScriptId}
+      tabId={tab.id}
+      active={active}
+      runScriptQuery={ignoreRunUntilDatabaseReady}
+      scriptState="idle"
+      databaseReady={false}
+    />
+  );
+};
 
 export const TabView = () => {
   const tabToTypeMap = useTabTypeMap();
@@ -25,7 +43,9 @@ export const TabView = () => {
     addToCache(activeTabId);
   }, [activeTabId, addToCache]);
 
-  if (appLoadState !== 'ready') {
+  const appCoreReady = appLoadState === 'core-ready' || appLoadState === 'ready';
+
+  if (!appCoreReady) {
     return (
       <Stack className="h-full gap-0 p-4" justify="center" align="center">
         <Skeleton width="60%" height={24} />
@@ -51,7 +71,12 @@ export const TabView = () => {
                   deleteTab([activeTabId]);
                 }}
               >
-                {tabType === 'script' && <ScriptTabView tabId={tabId} active={isActive} />}
+                {tabType === 'script' &&
+                  (appLoadState === 'ready' ? (
+                    <ScriptTabView tabId={tabId} active={isActive} />
+                  ) : (
+                    <CoreReadyScriptTabView tabId={tabId} active={isActive} />
+                  ))}
                 {tabType === 'data-source' && (
                   <FileDataSourceTabView tabId={tabId} active={isActive} />
                 )}

--- a/src/features/tabs-pane/tabs-pane.tsx
+++ b/src/features/tabs-pane/tabs-pane.tsx
@@ -53,7 +53,7 @@ export const TabsPane = memo(() => {
    * Store access
    */
   const appLoadState = useAppStore.use.appLoadState();
-  const appInitializing = appLoadState === 'init';
+  const appCoreReady = appLoadState === 'core-ready' || appLoadState === 'ready';
 
   const previewTabId = useAppStore.use.previewTabId();
   const activeTabId = useAppStore.use.activeTabId();
@@ -147,7 +147,7 @@ export const TabsPane = memo(() => {
           >
             <SortableContext items={orderedTabIds} strategy={horizontalListSortingStrategy}>
               <div className="flex items-center h-9" data-testid={setDataTestId('tabs-list')}>
-                {appInitializing ? (
+                {!appCoreReady ? (
                   <Skeleton className="ml-2" width={100} height={20} />
                 ) : (
                   orderedTabIds.map((tabId, idx) => {
@@ -181,7 +181,7 @@ export const TabsPane = memo(() => {
           </DndContext>
         </div>
       </ScrollArea>
-      <ActionIcon onClick={handleAddQuery} size={28} className="mx-2" disabled={appInitializing}>
+      <ActionIcon onClick={handleAddQuery} size={28} className="mx-2" disabled={!appCoreReady}>
         <IconPlus size={20} />
       </ActionIcon>
     </Group>

--- a/src/pages/main-page/components/accordion-content.tsx
+++ b/src/pages/main-page/components/accordion-content.tsx
@@ -64,6 +64,7 @@ export const AccordionContent = () => {
   }, [dataExplorerHeight]);
 
   const appReady = appLoadState === 'ready';
+  const appCoreReady = appLoadState === 'core-ready' || appReady;
   const bothExpanded = sectionStates.dataExplorer && sectionStates.queries;
 
   const toggleSection = (section: keyof SectionState) => {
@@ -310,7 +311,7 @@ export const AccordionContent = () => {
               Queries
             </Text>
           </Group>
-          {appReady && (
+          {appCoreReady && (
             <Group gap={4}>
               <ActionIcon
                 data-testid={setDataTestId('script-explorer-add-script-button')}
@@ -328,18 +329,20 @@ export const AccordionContent = () => {
               >
                 <IconPlus />
               </ActionIcon>
-              <ActionIcon
-                data-testid={setDataTestId('create-comparison-tab-button')}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  createComparisonTab({ setActive: true });
-                }}
-                size={16}
-                title="Compare Datasets"
-                aria-label="Create comparison tab"
-              >
-                <IconScale />
-              </ActionIcon>
+              {appReady && (
+                <ActionIcon
+                  data-testid={setDataTestId('create-comparison-tab-button')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    createComparisonTab({ setActive: true });
+                  }}
+                  size={16}
+                  title="Compare Datasets"
+                  aria-label="Create comparison tab"
+                >
+                  <IconScale />
+                </ActionIcon>
+              )}
             </Group>
           )}
         </Group>
@@ -352,7 +355,7 @@ export const AccordionContent = () => {
             maxHeight: sectionStates.queries ? 'calc(100% - 36px)' : undefined, // Subtract header height
           }}
         >
-          {appReady ? (
+          {appCoreReady ? (
             <ScriptExplorer />
           ) : (
             <Stack gap={6} className="px-3 py-1.5">

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -34,7 +34,7 @@ import { SpotlightView } from '../components/spotlight/model';
 import { TabExecutionError } from '../controllers/tab/tab-controller';
 import { SourceSelectionCallback } from '../features/comparison/hooks/use-comparison-source-selection';
 
-type AppLoadState = 'init' | 'ready' | 'error';
+type AppLoadState = 'init' | 'core-ready' | 'ready' | 'error';
 
 type AppStore = {
   /**
@@ -48,7 +48,8 @@ type AppStore = {
   _iDbConn: IDBPDatabase<AppIdbSchema> | null;
 
   /**
-   * The current state of the app, indicating whether it is loading, ready, or has encountered an error.
+   * The current state of the app. Core-ready means persisted scripts are available,
+   * while DuckDB-backed features are still initializing.
    */
   appLoadState: AppLoadState;
 

--- a/src/store/restore.ts
+++ b/src/store/restore.ts
@@ -49,7 +49,7 @@ import {
   AppIdbSchema,
 } from '@models/persisted-store';
 import { SQLScript, SQLScriptId, SQLScriptSession } from '@models/sql-script';
-import { ComparisonTab, TabId } from '@models/tab';
+import { AnyTab, ComparisonTab, TabId } from '@models/tab';
 import { AsyncDuckDBConnectionPool } from '@services/duckdb-pool/duckdb-connection-pool';
 import { makeSecretId, putSecret } from '@services/secret-store';
 import { useAppStore } from '@store/app-store';
@@ -130,6 +130,88 @@ type DiscardedEntry = {
   entry: LocalEntryPersistence;
   type: 'denied' | 'removed' | 'error' | 'warning';
   reason: string;
+};
+
+export type CoreAppDataSnapshot = {
+  iDbConn: IDBPDatabase<AppIdbSchema>;
+  sqlScripts: Map<SQLScriptId, SQLScript>;
+  tabs: Map<TabId, AnyTab>;
+  tabOrder: TabId[];
+  activeTabId: TabId | null;
+  previewTabId: TabId | null;
+  scriptAccessTimes: Map<SQLScriptId, number>;
+};
+
+type LegacySQLScript = SQLScript & { lastUsed?: number };
+
+const deserializeSqlScripts = (sqlScriptsArray: SQLScript[]): Map<SQLScriptId, SQLScript> => {
+  return new Map(
+    sqlScriptsArray.map((script) => {
+      const { lastUsed: _lastUsed, ...scriptWithoutLastUsed } = script as LegacySQLScript;
+      return [script.id, scriptWithoutLastUsed as SQLScript];
+    }),
+  );
+};
+
+const rebaseMapChanges = <K, V>(
+  restored: Map<K, V>,
+  baseline: Map<K, V>,
+  current: Map<K, V>,
+): Map<K, V> => {
+  const rebased = new Map(restored);
+
+  for (const key of baseline.keys()) {
+    if (!current.has(key)) rebased.delete(key);
+  }
+  for (const [key, value] of current) {
+    if (!baseline.has(key) || baseline.get(key) !== value) rebased.set(key, value);
+  }
+
+  return rebased;
+};
+
+export const rebaseCoreReadyChanges = ({
+  restoredSqlScripts,
+  restoredTabs,
+  restoredTabOrder,
+  restoredActiveTabId,
+  restoredPreviewTabId,
+  restoredScriptAccessTimes,
+  baseline,
+  current,
+}: {
+  restoredSqlScripts: Map<SQLScriptId, SQLScript>;
+  restoredTabs: Map<TabId, AnyTab>;
+  restoredTabOrder: TabId[];
+  restoredActiveTabId: TabId | null;
+  restoredPreviewTabId: TabId | null;
+  restoredScriptAccessTimes: Map<SQLScriptId, number>;
+  baseline: CoreAppDataSnapshot;
+  current: Pick<
+    CoreAppDataSnapshot,
+    'sqlScripts' | 'tabs' | 'tabOrder' | 'activeTabId' | 'previewTabId' | 'scriptAccessTimes'
+  >;
+}) => {
+  const tabsChanged = baseline.tabs !== current.tabs;
+  const baselineTabIds = new Set(baseline.tabs.keys());
+  const currentTabIds = new Set(current.tabs.keys());
+  const restoredOnlyTabOrder = restoredTabOrder.filter(
+    (tabId) => !baselineTabIds.has(tabId) && !currentTabIds.has(tabId),
+  );
+  const currentVisibleTabOrder = current.tabOrder.filter((tabId) => currentTabIds.has(tabId));
+
+  return {
+    sqlScripts: rebaseMapChanges(restoredSqlScripts, baseline.sqlScripts, current.sqlScripts),
+    tabs: rebaseMapChanges(restoredTabs, baseline.tabs, current.tabs),
+    tabOrder: tabsChanged ? [...restoredOnlyTabOrder, ...currentVisibleTabOrder] : restoredTabOrder,
+    activeTabId: tabsChanged ? current.activeTabId : restoredActiveTabId,
+    previewTabId: tabsChanged ? current.previewTabId : restoredPreviewTabId,
+    scriptAccessTimes: rebaseMapChanges(
+      restoredScriptAccessTimes,
+      baseline.scriptAccessTimes,
+      current.scriptAccessTimes,
+    ),
+  };
 };
 
 function createDiscardedEntryFromRemoved(entry: LocalEntryPersistence): DiscardedEntry {
@@ -457,6 +539,40 @@ async function restoreLocalEntries(
 }
 
 /**
+ * Restores only the persisted state needed for script browsing and editing.
+ * DuckDB-backed tabs, sessions, sources, and content-view state remain owned by
+ * the full restore once the connection pool is available.
+ */
+export const restoreCoreAppDataFromIDB = async (): Promise<CoreAppDataSnapshot> => {
+  const iDbConn = await getAppDataDBConnection();
+
+  // Script editing exposes the AI assistant, so initialize its persisted config
+  // before publishing core-ready even though it does not depend on DuckDB.
+  const { initAIConfigFromSecretStore } = await import('@utils/ai-config');
+  await initAIConfigFromSecretStore(iDbConn);
+
+  const sqlScriptsArray = await iDbConn.getAll(SQL_SCRIPT_TABLE_NAME);
+  const sqlScripts = deserializeSqlScripts(sqlScriptsArray);
+  const state = useAppStore.getState();
+
+  useAppStore.setState(
+    { _iDbConn: iDbConn, sqlScripts },
+    undefined,
+    'AppStore/restoreCoreAppDataFromIDB',
+  );
+
+  return {
+    iDbConn,
+    sqlScripts,
+    tabs: state.tabs,
+    tabOrder: state.tabOrder,
+    activeTabId: state.activeTabId,
+    previewTabId: state.previewTabId,
+    scriptAccessTimes: state.scriptAccessTimes,
+  };
+};
+
+/**
  * Hydrates the app data from IndexedDB into the store.
  *
  * This is not a hook, so can be used anywhere in the app.
@@ -466,15 +582,18 @@ async function restoreLocalEntries(
 export const restoreAppDataFromIDB = async (
   conn: AsyncDuckDBConnectionPool,
   onBeforeRequestFilePermission: (handles: FileSystemHandle[]) => Promise<boolean>,
+  coreSnapshot?: CoreAppDataSnapshot,
 ): Promise<{ discardedEntries: DiscardedEntry[]; warnings: string[] }> => {
-  const iDbConn = await getAppDataDBConnection();
+  const iDbConn = coreSnapshot?.iDbConn ?? (await getAppDataDBConnection());
 
   // Initialize AI config from the encrypted secret store (or migrate from cookie).
   // This must happen before reconnection triggers any `getAIConfig()` calls.
   // Dynamic import to avoid pulling ai-service.ts (which uses import.meta) into
   // the static import graph — Jest doesn't support import.meta outside modules.
-  const { initAIConfigFromSecretStore } = await import('@utils/ai-config');
-  await initAIConfigFromSecretStore(iDbConn);
+  if (!coreSnapshot) {
+    const { initAIConfigFromSecretStore } = await import('@utils/ai-config');
+    await initAIConfigFromSecretStore(iDbConn);
+  }
 
   const warnings: string[] = [];
   // iDB doesn't allow holding transaction while we await something
@@ -517,13 +636,7 @@ export const restoreAppDataFromIDB = async (
 
   // Read & Convert data to the appropriate types
   const sqlScriptsArray = await tx.objectStore(SQL_SCRIPT_TABLE_NAME).getAll();
-  type LegacySQLScript = SQLScript & { lastUsed?: number };
-  const sqlScripts = new Map(
-    sqlScriptsArray.map((script) => {
-      const { lastUsed: _lastUsed, ...scriptWithoutLastUsed } = script as LegacySQLScript;
-      return [script.id, scriptWithoutLastUsed as SQLScript];
-    }),
-  );
+  const sqlScripts = deserializeSqlScripts(sqlScriptsArray);
 
   const sqlScriptSessionsArray = await tx.objectStore(SQL_SCRIPT_SESSION_TABLE_NAME).getAll();
   const sqlScriptSessions = new Map<SQLScriptId, SQLScriptSession>(
@@ -1238,6 +1351,43 @@ export const restoreAppDataFromIDB = async (
     }
   }
 
+  // User actions remain enabled while the connection-dependent restore runs.
+  // Rebase any script/tab mutations made after core-ready onto the restored data.
+  const currentStateBeforeRestoreCommit = useAppStore.getState();
+  const hasCoreReadyTabChanges =
+    coreSnapshot !== undefined && coreSnapshot.tabs !== currentStateBeforeRestoreCommit.tabs;
+  const coreReadyChanges = coreSnapshot
+    ? rebaseCoreReadyChanges({
+        restoredSqlScripts: sqlScripts,
+        restoredTabs: newTabs,
+        restoredTabOrder: newTabOrder,
+        restoredActiveTabId: newActiveTabId,
+        restoredPreviewTabId: newPreviewTabId,
+        restoredScriptAccessTimes: scriptAccessTimes,
+        baseline: coreSnapshot,
+        current: currentStateBeforeRestoreCommit,
+      })
+    : {
+        sqlScripts,
+        tabs: newTabs,
+        tabOrder: newTabOrder,
+        activeTabId: newActiveTabId,
+        previewTabId: newPreviewTabId,
+        scriptAccessTimes,
+      };
+
+  if (hasCoreReadyTabChanges) {
+    // Restore cleanup can persist content-view changes after a core-ready tab
+    // action's fire-and-forget transaction. Write the rebased navigation state
+    // last so the gap tab also survives the next reload.
+    const contentViewTx = iDbConn.transaction(CONTENT_VIEW_TABLE_NAME, 'readwrite');
+    const contentViewStore = contentViewTx.objectStore(CONTENT_VIEW_TABLE_NAME);
+    await contentViewStore.put(coreReadyChanges.tabOrder, 'tabOrder');
+    await contentViewStore.put(coreReadyChanges.activeTabId, 'activeTabId');
+    await contentViewStore.put(coreReadyChanges.previewTabId, 'previewTabId');
+    await contentViewTx.done;
+  }
+
   // Finally update the store with the hydrated data
   useAppStore.setState(
     {
@@ -1246,15 +1396,15 @@ export const restoreAppDataFromIDB = async (
       dataSources,
       localEntries: localEntriesMap,
       registeredFiles,
-      sqlScripts,
+      sqlScripts: coreReadyChanges.sqlScripts,
       sqlScriptSessions,
       comparisons,
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-      activeTabId: newActiveTabId,
-      previewTabId: newPreviewTabId,
+      tabs: coreReadyChanges.tabs,
+      tabOrder: coreReadyChanges.tabOrder,
+      activeTabId: coreReadyChanges.activeTabId,
+      previewTabId: coreReadyChanges.previewTabId,
       dataSourceAccessTimes,
-      scriptAccessTimes,
+      scriptAccessTimes: coreReadyChanges.scriptAccessTimes,
       tableAccessTimes,
     },
     undefined,

--- a/tests/integration/startup/core-ready.spec.ts
+++ b/tests/integration/startup/core-ready.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../fixtures/page';
+
+type AppLoadTransition = {
+  state: string;
+  scriptExplorerVisible: boolean;
+  newScriptAvailable: boolean;
+};
+
+test('publishes interactive scripts before DuckDB-backed readiness', async ({
+  page,
+  reloadPage,
+}) => {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Network.enable');
+  await cdp.send('Network.clearBrowserCache');
+  await cdp.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency: 100,
+    downloadThroughput: 1_000_000,
+    uploadThroughput: 1_000_000,
+  });
+
+  await page.context().addInitScript(() => {
+    const transitions: AppLoadTransition[] = [];
+    Object.assign(window, { __appLoadTransitions: transitions });
+
+    const recordState = () => {
+      const appState = document.querySelector('[data-testid="app-state"]');
+      const state = appState?.getAttribute('data-app-load-state');
+      if (!state || transitions.at(-1)?.state === state) return;
+
+      transitions.push({
+        state,
+        scriptExplorerVisible: !!document.querySelector('[data-testid="script-explorer"]'),
+        newScriptAvailable: !!document.querySelector(
+          '[data-testid="script-explorer-add-script-button"]',
+        ),
+      });
+    };
+
+    new MutationObserver(recordState).observe(document, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      attributeFilter: ['data-app-load-state'],
+    });
+    queueMicrotask(recordState);
+  });
+
+  const readyPromise = reloadPage();
+  await expect(page.getByTestId('app-state')).toHaveAttribute('data-app-load-state', 'core-ready', {
+    timeout: 15_000,
+  });
+  await page.getByTestId('script-explorer-add-script-button').click();
+  await expect(
+    page.locator('[data-testid="query-editor"][data-active-editor="true"] .monaco-editor'),
+  ).toBeVisible();
+  await expect(page.getByTestId('run-query-button')).toBeDisabled();
+  await readyPromise;
+  await expect(page.getByTestId('run-query-button')).toBeEnabled();
+
+  await cdp.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency: 0,
+    downloadThroughput: -1,
+    uploadThroughput: -1,
+  });
+  await reloadPage();
+  await expect(
+    page.getByTestId('script-explorer').getByText('query.sql', { exact: true }),
+  ).toBeVisible();
+
+  const transitions = await page.evaluate(
+    () =>
+      (window as typeof window & { __appLoadTransitions: AppLoadTransition[] })
+        .__appLoadTransitions,
+  );
+  const coreReadyIndex = transitions.findIndex(({ state }) => state === 'core-ready');
+  const readyIndex = transitions.findIndex(({ state }) => state === 'ready');
+
+  expect(coreReadyIndex).toBeGreaterThanOrEqual(0);
+  expect(readyIndex).toBeGreaterThan(coreReadyIndex);
+  expect(transitions[coreReadyIndex]).toMatchObject({
+    scriptExplorerVisible: true,
+    newScriptAvailable: true,
+  });
+});

--- a/tests/unit/store/core-ready-rebase.test.ts
+++ b/tests/unit/store/core-ready-rebase.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from '@jest/globals';
+import { SQLScript, SQLScriptId } from '@models/sql-script';
+import { AnyTab, TabId } from '@models/tab';
+import { CoreAppDataSnapshot, rebaseCoreReadyChanges } from '@store/restore';
+
+const script = (id: string, content: string): SQLScript => ({
+  id: id as SQLScriptId,
+  name: id,
+  content,
+});
+
+const scriptTab = (id: string, scriptId: string): AnyTab => ({
+  id: id as TabId,
+  type: 'script',
+  sqlScriptId: scriptId as SQLScriptId,
+  dataViewPaneHeight: 0,
+  editorPaneHeight: 0,
+  lastExecutedQuery: null,
+  dataViewStateCache: null,
+});
+
+const snapshot = (overrides: Partial<CoreAppDataSnapshot> = {}): CoreAppDataSnapshot => ({
+  iDbConn: {} as CoreAppDataSnapshot['iDbConn'],
+  sqlScripts: new Map(),
+  tabs: new Map(),
+  tabOrder: [],
+  activeTabId: null,
+  previewTabId: null,
+  scriptAccessTimes: new Map(),
+  ...overrides,
+});
+
+describe('core-ready restore rebase', () => {
+  it('preserves scripts created, edited, and deleted while the full restore runs', () => {
+    const unchanged = script('unchanged', 'select 1');
+    const edited = script('edited', 'select 2');
+    const deleted = script('deleted', 'select 3');
+    const baseline = snapshot({
+      sqlScripts: new Map([
+        [unchanged.id, unchanged],
+        [edited.id, edited],
+        [deleted.id, deleted],
+      ]),
+    });
+    const restoredUnchanged = script('unchanged', 'migrated by restore');
+    const currentEdit = script('edited', 'select 42');
+    const created = script('created', 'select 99');
+
+    const result = rebaseCoreReadyChanges({
+      restoredSqlScripts: new Map([
+        [restoredUnchanged.id, restoredUnchanged],
+        [edited.id, edited],
+        [deleted.id, deleted],
+      ]),
+      restoredTabs: new Map(),
+      restoredTabOrder: [],
+      restoredActiveTabId: null,
+      restoredPreviewTabId: null,
+      restoredScriptAccessTimes: new Map(),
+      baseline,
+      current: {
+        ...baseline,
+        sqlScripts: new Map([
+          [unchanged.id, unchanged],
+          [currentEdit.id, currentEdit],
+          [created.id, created],
+        ]),
+      },
+    });
+
+    expect(result.sqlScripts.get(unchanged.id)).toBe(restoredUnchanged);
+    expect(result.sqlScripts.get(edited.id)).toBe(currentEdit);
+    expect(result.sqlScripts.get(created.id)).toBe(created);
+    expect(result.sqlScripts.has(deleted.id)).toBe(false);
+  });
+
+  it('keeps restored tabs and appends tabs opened during core-ready', () => {
+    const restoredTab = scriptTab('restored-tab', 'restored-script');
+    const gapTab = scriptTab('gap-tab', 'gap-script');
+    const baseline = snapshot();
+
+    const result = rebaseCoreReadyChanges({
+      restoredSqlScripts: new Map(),
+      restoredTabs: new Map([[restoredTab.id, restoredTab]]),
+      restoredTabOrder: [restoredTab.id],
+      restoredActiveTabId: restoredTab.id,
+      restoredPreviewTabId: null,
+      restoredScriptAccessTimes: new Map(),
+      baseline,
+      current: {
+        ...baseline,
+        tabs: new Map([[gapTab.id, gapTab]]),
+        tabOrder: [gapTab.id],
+        activeTabId: gapTab.id,
+        previewTabId: gapTab.id,
+      },
+    });
+
+    expect(Array.from(result.tabs.keys())).toEqual([restoredTab.id, gapTab.id]);
+    expect(result.tabOrder).toEqual([restoredTab.id, gapTab.id]);
+    expect(result.activeTabId).toBe(gapTab.id);
+    expect(result.previewTabId).toBe(gapTab.id);
+  });
+
+  it('preserves tab deletion and reordering after a blocked-tab restart', () => {
+    const first = scriptTab('first', 'first-script');
+    const second = scriptTab('second', 'second-script');
+    const baseline = snapshot({
+      tabs: new Map([
+        [first.id, first],
+        [second.id, second],
+      ]),
+      tabOrder: [first.id, second.id],
+      activeTabId: first.id,
+    });
+
+    const result = rebaseCoreReadyChanges({
+      restoredSqlScripts: new Map(),
+      restoredTabs: new Map(baseline.tabs),
+      restoredTabOrder: baseline.tabOrder,
+      restoredActiveTabId: baseline.activeTabId,
+      restoredPreviewTabId: null,
+      restoredScriptAccessTimes: new Map(),
+      baseline,
+      current: {
+        ...baseline,
+        tabs: new Map([[second.id, second]]),
+        tabOrder: [second.id],
+        activeTabId: second.id,
+      },
+    });
+
+    expect(Array.from(result.tabs.keys())).toEqual([second.id]);
+    expect(result.tabOrder).toEqual([second.id]);
+    expect(result.activeTabId).toBe(second.id);
+  });
+});


### PR DESCRIPTION
Stage 3 — the final startup-plan stage (after #318, #329). On cold cache the multi-MB WASM fetches kept the whole UI in skeletons even though script browsing/editing needs no DuckDB.

## State machine
`init → core-ready → ready` (`error` reachable from both). **core-ready** = IndexedDB scripts + AI config hydrated, concurrent with DuckDB boot. It publishes: Queries/Script Explorer, new-script action, fully editable Monaco, tabs created in the gap — with **Run disabled via the existing affordance** until `ready`. Data explorer, add-datasource, comparisons, and session-bearing restored tabs stay gated on `ready` (deliberate: no unattached sources exposed).

## The clobber problem (the hard part)
The full restore commits one atomic `setState`. Work done during the gap is **rebased** onto it — a three-way merge (baseline/current/restored) over scripts, tabs, ordering, selection, and access times, persisted after commit. Unit-covered (`core-ready-rebase.test.ts`) and integration-proven: under cleared cache + network throttling, a script created at core-ready survives the transition **and a subsequent reload** (`tests/integration/startup/core-ready.spec.ts`, verified independently).

## Hazards
- Tab-coordination block/unblock: initialization generations prevent a superseded run publishing `ready`
- DuckDB boot failure still reaches `error` + existing failure UI (no core-ready stranding)
- Persisted session-bearing tabs untouched (conn-dependent restore owns them)

## Gates
typecheck · unit+coverage (1184 tests, 82.26% branches) · eslint 0 errors · prettier · build + budget (6.08 MB) · full Chromium suite (166 passed; known locals only) · `--immutable` — all exit 0