### PR TITLE
refactor(store): move tab state mutations into named store actions

### DIFF
--- a/src/controllers/tab/tab-controller.ts
+++ b/src/controllers/tab/tab-controller.ts
@@ -27,7 +27,25 @@ import {
   TabId,
 } from '@models/tab';
 import { getCurrentDuckDBConnectionPool } from '@services/duckdb-pool/current-pool';
-import { useAppStore } from '@store/app-store';
+import {
+  clearAllTabExecutionErrors as clearAllTabExecutionErrorsAction,
+  clearTabExecutionError as clearTabExecutionErrorAction,
+  closeTabs as closeTabsAction,
+  createTab as createTabAction,
+  markTabExecutionError,
+  reorderTabs,
+  replacePreviewTab,
+  setActiveTab,
+  setPreviewTab,
+  updateScriptTabLastExecutedQuery as updateScriptTabLastExecutedQueryAction,
+  updateScriptTabLayout as updateScriptTabLayoutAction,
+  updateTabChartConfig as updateTabChartConfigAction,
+  updateTabDataViewColumnSizesCache as updateTabDataViewColumnSizesCacheAction,
+  updateTabDataViewDataPageCache as updateTabDataViewDataPageCacheAction,
+  updateTabDataViewStaleDataCache as updateTabDataViewStaleDataCacheAction,
+  updateTabViewMode as updateTabViewModeAction,
+  useAppStore,
+} from '@store/app-store';
 import {
   ensureDatabaseDataSource,
   ensureFlatFileDataSource,
@@ -47,7 +65,6 @@ import { shallow } from 'zustand/shallow';
 
 import { persistCreateTab, persistDeleteTab } from './persist';
 import {
-  deleteTabImpl,
   findTabFromLocalDBObjectImpl,
   findTabFromFlatFileDataSourceImpl,
   findTabFromScriptImpl,
@@ -211,19 +228,8 @@ export const getOrCreateSchemaBrowserTab = (options: {
     dataViewStateCache: null,
   };
 
-  const newTabs = new Map(state.tabs).set(tabId, tab);
-  const newTabOrder = [...state.tabOrder, tabId];
   const newActiveTabId = setActive ? tabId : state.activeTabId;
-
-  useAppStore.setState(
-    (_) => ({
-      activeTabId: newActiveTabId,
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-    }),
-    undefined,
-    'AppStore/createSchemaBrowserTab',
-  );
+  const newTabOrder = createTabAction(tab, newActiveTabId);
 
   const iDb = state._iDbConn;
   if (iDb) {
@@ -299,17 +305,7 @@ export const getOrCreateTabFromLocalDBObject = (
   };
 
   // Add the new tab to the store
-  const newTabs = new Map(state.tabs).set(tabId, tab);
-  const newTabOrder = [...state.tabOrder, tabId];
-
-  useAppStore.setState(
-    (_) => ({
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-    }),
-    undefined,
-    'AppStore/createTabFromPersistentDataView',
-  );
+  const newTabOrder = createTabAction(tab);
 
   // Persist the new tab to IndexedDB
   const iDb = state._iDbConn;
@@ -368,17 +364,7 @@ export const getOrCreateTabFromFlatFileDataSource = (
   };
 
   // Add the new tab to the store
-  const newTabs = new Map(state.tabs).set(tabId, tab);
-  const newTabOrder = [...state.tabOrder, tabId];
-
-  useAppStore.setState(
-    (_) => ({
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-    }),
-    undefined,
-    'AppStore/createTabFromPersistentDataView',
-  );
+  const newTabOrder = createTabAction(tab);
 
   // Persist the new tab to IndexedDB
   const iDb = state._iDbConn;
@@ -444,17 +430,7 @@ export const getOrCreateTabFromScript = (
   };
 
   // Add the new tab to the store
-  const newTabs = new Map(state.tabs).set(tabId, tab);
-  const newTabOrder = [...state.tabOrder, tabId];
-
-  useAppStore.setState(
-    (_) => ({
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-    }),
-    undefined,
-    'AppStore/createTabFromScript',
-  );
+  const newTabOrder = createTabAction(tab);
 
   // Persist the new tab to IndexedDB
   const iDb = state._iDbConn;
@@ -631,18 +607,7 @@ export const updateTabDataViewStaleDataCache = (
     }),
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateTabDataViewStaleDataCache',
-  );
+  updateTabDataViewStaleDataCacheAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -676,18 +641,7 @@ export const updateTabDataViewColumnSizesCache = (
     }),
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateTabDataViewColumnSizesCache',
-  );
+  updateTabDataViewColumnSizesCacheAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -718,18 +672,7 @@ export const updateTabDataViewDataPageCache = (tabId: TabId, newDataPage: number
     }),
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateTabDataViewDataPageCache',
-  );
+  updateTabDataViewDataPageCacheAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -781,18 +724,7 @@ export const updateScriptTabLastExecutedQuery = ({
     lastExecutedQuery,
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateScriptTabLastExecutedQuery',
-  );
+  updateScriptTabLastExecutedQueryAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -832,18 +764,7 @@ export const updateScriptTabLayout = (
     dataViewPaneHeight,
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateScriptTabLayout',
-  );
+  updateScriptTabLayoutAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -879,17 +800,7 @@ export const updateTabViewMode = (tabId: TabId, viewMode: ViewMode): void => {
     dataViewStateCache: updateDataViewStateCache(currentTab.dataViewStateCache, { viewMode }),
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateTabViewMode',
-  );
+  updateTabViewModeAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -959,17 +870,7 @@ export const updateTabChartConfig = (tabId: TabId, chartConfig: Partial<ChartCon
     }),
   };
 
-  // Update the store
-  const newTabs = new Map(tabs);
-  newTabs.set(currentTab.id, updatedTab);
-
-  useAppStore.setState(
-    {
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/updateTabChartConfig',
-  );
+  updateTabChartConfigAction(updatedTab);
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -1033,7 +934,7 @@ export const setActiveTabId = (tabId: TabId | null) => {
   // If the tab is already active, skip state update and persistence
   if (activeTabId === tabId) return;
 
-  useAppStore.setState({ activeTabId: tabId }, undefined, 'AppStore/setActiveTabId');
+  setActiveTab(tabId);
 
   const iDb = useAppStore.getState()._iDbConn;
   if (iDb) {
@@ -1060,7 +961,7 @@ export const setActiveTabId = (tabId: TabId | null) => {
  * @param tabId - The id of the tab to set as preview or null to reset.
  */
 export const setPreviewTabId = (tabId: TabId | null) => {
-  const { tabs, tabOrder, activeTabId, previewTabId, _iDbConn: iDbConn } = useAppStore.getState();
+  const { tabs, previewTabId, _iDbConn: iDbConn } = useAppStore.getState();
 
   // Check we have stuff to do
   if (previewTabId === tabId) return;
@@ -1075,24 +976,9 @@ export const setPreviewTabId = (tabId: TabId | null) => {
       saveScriptDataViewStateCache(previewTab.sqlScriptId, previewTab.dataViewStateCache);
     }
 
-    const { newTabs, newTabOrder, newActiveTabId } = deleteTabImpl({
-      deleteTabIds: [previewTabId],
-      tabs,
-      tabOrder,
-      activeTabId,
+    const { activeTabId: newActiveTabId, tabOrder: newTabOrder } = replacePreviewTab(
       previewTabId,
-    });
-
-    // Update the store with the new state
-    useAppStore.setState(
-      {
-        tabs: newTabs,
-        tabOrder: newTabOrder,
-        activeTabId: newActiveTabId,
-        previewTabId: tabId,
-      },
-      undefined,
-      'AppStore/setPreviewTabId',
+      tabId,
     );
 
     if (iDbConn) {
@@ -1103,7 +989,7 @@ export const setPreviewTabId = (tabId: TabId | null) => {
   }
 
   // Case 1 or 3
-  useAppStore.setState({ previewTabId: tabId }, undefined, 'AppStore/setPreviewTabId');
+  setPreviewTab(tabId);
 
   if (iDbConn) {
     iDbConn
@@ -1113,7 +999,7 @@ export const setPreviewTabId = (tabId: TabId | null) => {
 };
 
 export const setTabOrder = (tabOrder: TabId[]) => {
-  useAppStore.setState({ tabOrder }, undefined, 'AppStore/setTabOrder');
+  reorderTabs(tabOrder);
 
   const iDb = useAppStore.getState()._iDbConn;
   if (iDb) {
@@ -1192,58 +1078,16 @@ export const deleteTab = async (tabIds: TabId[]) => {
       }
     }
 
-    let persistencePayload: {
-      newActiveTabId: TabId | null;
-      newPreviewTabId: TabId | null;
-      newTabOrder: TabId[];
-    } | null = null;
-
-    // Update the store with the latest snapshot to avoid racing with other deletions
-    useAppStore.setState(
-      (state) => {
-        const { newTabs, newTabOrder, newActiveTabId, newPreviewTabId } = deleteTabImpl({
-          deleteTabIds: tabIds,
-          tabs: state.tabs,
-          tabOrder: state.tabOrder,
-          activeTabId: state.activeTabId,
-          previewTabId: state.previewTabId,
-        });
-
-        const newTabExecutionErrors = new Map(state.tabExecutionErrors);
-        tabIds.forEach((tabId) => newTabExecutionErrors.delete(tabId));
-
-        persistencePayload = {
-          newActiveTabId,
-          newPreviewTabId,
-          newTabOrder,
-        };
-
-        return {
-          tabs: newTabs,
-          tabOrder: newTabOrder,
-          activeTabId: newActiveTabId,
-          previewTabId: newPreviewTabId,
-          tabExecutionErrors: newTabExecutionErrors,
-        };
-      },
-      undefined,
-      'AppStore/deleteTab',
-    );
-
-    // persistencePayload is definitely assigned by setState callback above
-    const payload = persistencePayload as {
-      newActiveTabId: TabId | null;
-      newPreviewTabId: TabId | null;
-      newTabOrder: TabId[];
-    } | null;
-    if (iDbConn && payload) {
+    // The action reads the latest snapshot to avoid racing with other deletions.
+    const payload = closeTabsAction(tabIds);
+    if (iDbConn) {
       // Now we can pass the entire array (or single ID) directly
       persistDeleteTab(
         iDbConn,
         tabIds,
-        payload.newActiveTabId,
-        payload.newPreviewTabId,
-        payload.newTabOrder,
+        payload.activeTabId,
+        payload.previewTabId,
+        payload.tabOrder,
       );
     }
   } finally {
@@ -1318,16 +1162,7 @@ export const deleteTabByDataSourceId = async (
  * @param error - The execution error details
  */
 export const setTabExecutionError = (tabId: TabId, error: TabExecutionError): void => {
-  const { tabExecutionErrors } = useAppStore.getState();
-
-  const newErrors = new Map(tabExecutionErrors);
-  newErrors.set(tabId, error);
-
-  useAppStore.setState(
-    { tabExecutionErrors: newErrors },
-    undefined,
-    'TabController/setExecutionError',
-  );
+  markTabExecutionError(tabId, error);
 };
 
 /**
@@ -1336,29 +1171,12 @@ export const setTabExecutionError = (tabId: TabId, error: TabExecutionError): vo
  * @param tabId - The ID of the tab
  */
 export const clearTabExecutionError = (tabId: TabId): void => {
-  const { tabExecutionErrors } = useAppStore.getState();
-
-  if (!tabExecutionErrors.has(tabId)) {
-    return; // No error to clear
-  }
-
-  const newErrors = new Map(tabExecutionErrors);
-  newErrors.delete(tabId);
-
-  useAppStore.setState(
-    { tabExecutionErrors: newErrors },
-    undefined,
-    'TabController/clearExecutionError',
-  );
+  clearTabExecutionErrorAction(tabId);
 };
 
 /**
  * Clears all tab execution errors.
  */
 export const clearAllTabExecutionErrors = (): void => {
-  useAppStore.setState(
-    { tabExecutionErrors: new Map() },
-    undefined,
-    'TabController/clearAllExecutionErrors',
-  );
+  clearAllTabExecutionErrorsAction();
 };

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -1,5 +1,6 @@
 import { IconType } from '@components/named-icon';
 import { persistPutSqlScriptSession } from '@controllers/sql-script/persist';
+import { deleteTabImpl } from '@controllers/tab/pure';
 import { PROGRESS_CLEANUP_MAX_AGE_MS } from '@features/comparison/config/execution-config';
 import { Comparison, ComparisonExecutionProgress, ComparisonId } from '@models/comparison';
 import { ContentViewState } from '@models/content-view';
@@ -20,7 +21,7 @@ import { ExportFormat } from '@models/export-options';
 import { LocalEntry, LocalEntryId, LocalFile } from '@models/file-system';
 import { AppIdbSchema } from '@models/persisted-store';
 import { SQLScript, SQLScriptId, SQLScriptSession } from '@models/sql-script';
-import { AnyTab, TabId, TabReactiveState, TabType } from '@models/tab';
+import { AnyTab, ScriptTab, TabId, TabReactiveState, TabType } from '@models/tab';
 import { getDatabaseIdentifier, isFlatFileDataSource } from '@utils/data-source';
 import { getTabIcon, getTabName } from '@utils/navigation';
 import { IDBPDatabase } from 'idb';
@@ -31,7 +32,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { resetAppData } from './restore';
 import { createSelectors } from './utils';
 import { SpotlightView } from '../components/spotlight/model';
-import { TabExecutionError } from '../controllers/tab/tab-controller';
+import type { TabExecutionError } from '../controllers/tab/tab-controller';
 import { SourceSelectionCallback } from '../features/comparison/hooks/use-comparison-source-selection';
 
 type AppLoadState = 'init' | 'core-ready' | 'ready' | 'error';
@@ -698,6 +699,238 @@ export const setIDbConn = (iDbConn: IDBPDatabase<AppIdbSchema>) => {
 
 export const setDuckDBFunctions = (functions: DBFunctionsMetadata[]) => {
   useAppStore.setState({ duckDBFunctions: functions }, undefined, 'AppStore/setDuckDBFunctions');
+};
+
+export const createTab = (tab: AnyTab, activeTabId?: TabId | null): TabId[] => {
+  let nextTabOrder: TabId[] = [];
+
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs).set(tab.id, tab);
+      const tabOrder = [...state.tabOrder, tab.id];
+      nextTabOrder = tabOrder;
+
+      return activeTabId === undefined ? { tabs, tabOrder } : { tabs, tabOrder, activeTabId };
+    },
+    undefined,
+    'AppStore/createTab',
+  );
+
+  return nextTabOrder;
+};
+
+export const updateTabDataViewStaleDataCache = (tab: AnyTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateTabDataViewStaleDataCache',
+  );
+};
+
+export const updateTabDataViewColumnSizesCache = (tab: AnyTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateTabDataViewColumnSizesCache',
+  );
+};
+
+export const updateTabDataViewDataPageCache = (tab: AnyTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateTabDataViewDataPageCache',
+  );
+};
+
+export const updateScriptTabLastExecutedQuery = (tab: ScriptTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateScriptTabLastExecutedQuery',
+  );
+};
+
+export const updateScriptTabLayout = (tab: ScriptTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateScriptTabLayout',
+  );
+};
+
+export const updateTabViewMode = (tab: AnyTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateTabViewMode',
+  );
+};
+
+export const updateTabChartConfig = (tab: AnyTab): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs);
+      tabs.set(tab.id, tab);
+      return { tabs };
+    },
+    undefined,
+    'AppStore/updateTabChartConfig',
+  );
+};
+
+export const setActiveTab = (tabId: TabId | null): void => {
+  useAppStore.setState({ activeTabId: tabId }, undefined, 'AppStore/setActiveTab');
+};
+
+export const setPreviewTab = (tabId: TabId | null): void => {
+  useAppStore.setState({ previewTabId: tabId }, undefined, 'AppStore/setPreviewTab');
+};
+
+type CloseTabsResult = {
+  activeTabId: TabId | null;
+  previewTabId: TabId | null;
+  tabOrder: TabId[];
+};
+
+export const replacePreviewTab = (previewTabId: TabId, tabId: TabId): CloseTabsResult => {
+  let result: CloseTabsResult = {
+    activeTabId: null,
+    previewTabId: tabId,
+    tabOrder: [],
+  };
+
+  useAppStore.setState(
+    (state) => {
+      const { newTabs, newTabOrder, newActiveTabId } = deleteTabImpl({
+        deleteTabIds: [previewTabId],
+        tabs: state.tabs,
+        tabOrder: state.tabOrder,
+        activeTabId: state.activeTabId,
+        previewTabId: state.previewTabId,
+      });
+
+      result = {
+        activeTabId: newActiveTabId,
+        previewTabId: tabId,
+        tabOrder: newTabOrder,
+      };
+
+      return {
+        tabs: newTabs,
+        tabOrder: newTabOrder,
+        activeTabId: newActiveTabId,
+        previewTabId: tabId,
+      };
+    },
+    undefined,
+    'AppStore/replacePreviewTab',
+  );
+
+  return result;
+};
+
+export const reorderTabs = (tabOrder: TabId[]): void => {
+  useAppStore.setState({ tabOrder }, undefined, 'AppStore/reorderTabs');
+};
+
+export const closeTabs = (tabIds: TabId[]): CloseTabsResult => {
+  let result: CloseTabsResult = {
+    activeTabId: null,
+    previewTabId: null,
+    tabOrder: [],
+  };
+
+  useAppStore.setState(
+    (state) => {
+      const { newTabs, newTabOrder, newActiveTabId, newPreviewTabId } = deleteTabImpl({
+        deleteTabIds: tabIds,
+        tabs: state.tabs,
+        tabOrder: state.tabOrder,
+        activeTabId: state.activeTabId,
+        previewTabId: state.previewTabId,
+      });
+
+      const tabExecutionErrors = new Map(state.tabExecutionErrors);
+      tabIds.forEach((tabId) => tabExecutionErrors.delete(tabId));
+
+      result = {
+        activeTabId: newActiveTabId,
+        previewTabId: newPreviewTabId,
+        tabOrder: newTabOrder,
+      };
+
+      return {
+        tabs: newTabs,
+        tabOrder: newTabOrder,
+        activeTabId: newActiveTabId,
+        previewTabId: newPreviewTabId,
+        tabExecutionErrors,
+      };
+    },
+    undefined,
+    'AppStore/closeTabs',
+  );
+
+  return result;
+};
+
+export const markTabExecutionError = (tabId: TabId, error: TabExecutionError): void => {
+  useAppStore.setState(
+    (state) => {
+      const tabExecutionErrors = new Map(state.tabExecutionErrors);
+      tabExecutionErrors.set(tabId, error);
+      return { tabExecutionErrors };
+    },
+    undefined,
+    'AppStore/markTabExecutionError',
+  );
+};
+
+export const clearTabExecutionError = (tabId: TabId): void => {
+  if (!useAppStore.getState().tabExecutionErrors.has(tabId)) return;
+
+  useAppStore.setState(
+    (state) => {
+      const tabExecutionErrors = new Map(state.tabExecutionErrors);
+      tabExecutionErrors.delete(tabId);
+      return { tabExecutionErrors };
+    },
+    undefined,
+    'AppStore/clearTabExecutionError',
+  );
+};
+
+export const clearAllTabExecutionErrors = (): void => {
+  useAppStore.setState(
+    { tabExecutionErrors: new Map() },
+    undefined,
+    'AppStore/clearAllTabExecutionErrors',
+  );
 };
 
 export const setScriptSession = (scriptId: SQLScriptId, session: SQLScriptSession) => {

--- a/tests/unit/controllers/tab/tab-controller.test.ts
+++ b/tests/unit/controllers/tab/tab-controller.test.ts
@@ -10,6 +10,11 @@ let mockTabs: Map<TabId, AnyTab>;
 jest.mock('@store/app-store', () => {
   mockSetState = jest.fn();
   mockTabs = new Map();
+  const updateTab = (tab: AnyTab) => {
+    const tabs = new Map(mockTabs);
+    tabs.set(tab.id, tab);
+    mockSetState({ tabs });
+  };
   return {
     useAppStore: {
       getState: () => ({
@@ -18,6 +23,8 @@ jest.mock('@store/app-store', () => {
       }),
       setState: mockSetState,
     },
+    updateTabViewMode: updateTab,
+    updateTabChartConfig: updateTab,
   };
 });
 

--- a/tests/unit/store/tab-actions.test.ts
+++ b/tests/unit/store/tab-actions.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { SQLScriptId } from '@models/sql-script';
+import { AnyTab, TabId } from '@models/tab';
+import { closeTabs, replacePreviewTab, useAppStore } from '@store/app-store';
+
+const tab = (id: string): AnyTab => ({
+  id: id as TabId,
+  type: 'script',
+  sqlScriptId: `script-${id}` as SQLScriptId,
+  dataViewPaneHeight: 0,
+  editorPaneHeight: 0,
+  lastExecutedQuery: null,
+  dataViewStateCache: null,
+});
+
+describe('tab store actions', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: new Map(),
+      tabOrder: [],
+      activeTabId: null,
+      previewTabId: null,
+      tabExecutionErrors: new Map(),
+    });
+  });
+
+  it('closes tabs and cascades active, preview, order, and execution-error state', () => {
+    const first = tab('first');
+    const closing = tab('closing');
+    const last = tab('last');
+    const originalTabs = new Map([
+      [first.id, first],
+      [closing.id, closing],
+      [last.id, last],
+    ]);
+    const closingError = { errorMessage: 'closing failed', timestamp: 1 };
+    const lastError = { errorMessage: 'last failed', timestamp: 2 };
+
+    useAppStore.setState({
+      tabs: originalTabs,
+      tabOrder: [first.id, closing.id, last.id],
+      activeTabId: closing.id,
+      previewTabId: closing.id,
+      tabExecutionErrors: new Map([
+        [closing.id, closingError],
+        [last.id, lastError],
+      ]),
+    });
+
+    const result = closeTabs([closing.id]);
+    const state = useAppStore.getState();
+
+    expect(result).toEqual({
+      activeTabId: first.id,
+      previewTabId: null,
+      tabOrder: [first.id, last.id],
+    });
+    expect(state.tabs).not.toBe(originalTabs);
+    expect(Array.from(state.tabs.keys())).toEqual([first.id, last.id]);
+    expect(state.tabOrder).toEqual([first.id, last.id]);
+    expect(state.activeTabId).toBe(first.id);
+    expect(state.previewTabId).toBeNull();
+    expect(state.tabExecutionErrors).toEqual(new Map([[last.id, lastError]]));
+    expect(originalTabs.has(closing.id)).toBe(true);
+  });
+
+  it('replaces a preview tab and preserves unrelated tab execution errors', () => {
+    const first = tab('first');
+    const preview = tab('preview');
+    const replacement = tab('replacement');
+    const previewError = { errorMessage: 'preview failed', timestamp: 1 };
+
+    useAppStore.setState({
+      tabs: new Map([
+        [first.id, first],
+        [preview.id, preview],
+        [replacement.id, replacement],
+      ]),
+      tabOrder: [first.id, preview.id, replacement.id],
+      activeTabId: preview.id,
+      previewTabId: preview.id,
+      tabExecutionErrors: new Map([[preview.id, previewError]]),
+    });
+
+    const result = replacePreviewTab(preview.id, replacement.id);
+    const state = useAppStore.getState();
+
+    expect(result).toEqual({
+      activeTabId: first.id,
+      previewTabId: replacement.id,
+      tabOrder: [first.id, replacement.id],
+    });
+    expect(Array.from(state.tabs.keys())).toEqual([first.id, replacement.id]);
+    expect(state.activeTabId).toBe(first.id);
+    expect(state.previewTabId).toBe(replacement.id);
+    expect(state.tabExecutionErrors.get(preview.id)).toBe(previewError);
+  });
+});


### PR DESCRIPTION
First increment of the store-actions migration (July audit: ~106 scattered `useAppStore.setState` calls, no single owner of state transitions).

## Tabs domain
All **19** raw `setState` sites in `tab-controller.ts` extracted into **16 named actions** colocated with the store's existing action section (`AppStore/<name>` devtools labels; copy-on-write Map updates byte-for-byte in style). Controller keeps orchestration (persistence, DuckDB); only mutations moved. `pure.ts` stays pure. Comparison-tab writes deliberately untouched (next increment).

Highlights: `closeTabs` now owns the active/preview/order/error cascade (focused unit tests added); `setPreviewTab`/`replacePreviewTab` split the two semantic branches of the old `setPreviewTabId`.

## Verification
Existing controller tests passed with behavioral assertions unchanged (only a mock adapter). 72 suites / 1186 unit tests, 82.2% branches · typecheck · eslint 0 errors · prettier · build + budget · `--immutable` — all exit 0. Tab flows are heavily covered by the integration suite on CI.