### PR TITLE
refactor(store): move comparison state mutations into named store actions

### DIFF
--- a/src/controllers/comparison/comparison-controller.ts
+++ b/src/controllers/comparison/comparison-controller.ts
@@ -3,7 +3,6 @@
 
 import { showWarning } from '@components/app-notifications';
 import { persistDeleteTab } from '@controllers/tab/persist';
-import { deleteTabImpl } from '@controllers/tab/pure';
 import { refreshDatabaseMetadata } from '@features/data-explorer/utils/metadata-refresh';
 import {
   Comparison,
@@ -13,15 +12,23 @@ import {
 } from '@models/comparison';
 import { PERSISTENT_DB_NAME } from '@models/db-persistence';
 import { COMPARISON_TABLE_NAME, TAB_TABLE_NAME } from '@models/persisted-store';
-import { ComparisonTab, TabId } from '@models/tab';
 import { AsyncDuckDBConnectionPool } from '@services/duckdb-pool/duckdb-connection-pool';
-import { useAppStore } from '@store/app-store';
+import {
+  clearComparisonResults as clearComparisonResultsInStore,
+  createComparison as createComparisonInStore,
+  deleteComparisons as deleteComparisonsInStore,
+  renameComparison as renameComparisonInStore,
+  updateComparisonConfig as updateComparisonConfigInStore,
+  updateComparisonExecutionTime as updateComparisonExecutionTimeInStore,
+  updateComparisonResultsTable as updateComparisonResultsTableInStore,
+  updateComparisonSchemaAnalysis as updateComparisonSchemaAnalysisInStore,
+  useAppStore,
+} from '@store/app-store';
 import { setComparisonPartialResults } from '@store/comparison-metadata';
 import { ensureComparison, makeComparisonId } from '@utils/comparison';
 import { findUniqueName, getAllExistingNames } from '@utils/helpers';
 
 import { persistDeleteComparison } from './persist';
-import { deleteComparisonImpl } from './pure';
 import { dropComparisonResultsTable } from './table-utils';
 
 /**
@@ -56,14 +63,7 @@ export const createComparison = (
     },
   };
 
-  // Add the new comparison to the store
-  useAppStore.setState(
-    (state) => ({
-      comparisons: new Map(state.comparisons).set(comparisonId, comparison),
-    }),
-    undefined,
-    'AppStore/createComparison',
-  );
+  createComparisonInStore(comparison);
 
   // Persist the new comparison to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -95,24 +95,8 @@ export const updateComparisonConfig = (
   // Check if the comparison exists
   const comparison = ensureComparison(comparisonOrId, comparisons);
 
-  // Create updated comparison
-  const updatedComparison: Comparison = {
-    ...comparison,
-    config,
-  };
-
-  // Update the store
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-    },
-    undefined,
-    'AppStore/updateComparisonConfig',
-  );
+  const updatedComparison = updateComparisonConfigInStore(comparison.id, config);
+  if (!updatedComparison) return;
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -125,7 +109,7 @@ export const clearComparisonResults = async (
   comparisonOrId: Comparison | ComparisonId,
   options?: { pool?: AsyncDuckDBConnectionPool | null; tableNameOverride?: string | null },
 ): Promise<void> => {
-  const { comparisons, tabs, _iDbConn: iDbConn } = useAppStore.getState();
+  const { comparisons, _iDbConn: iDbConn } = useAppStore.getState();
   const comparison = ensureComparison(comparisonOrId, comparisons);
 
   if (!comparison.resultsTableName && comparison.lastExecutionTime === null) {
@@ -146,45 +130,15 @@ export const clearComparisonResults = async (
     }
   }
 
-  const updatedComparison: Comparison = {
-    ...comparison,
-    resultsTableName: null,
-    lastExecutionTime: null,
-    lastRunAt: null,
-  };
-
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  const newTabs = new Map(tabs);
-  const updatedTabIds: TabId[] = [];
-
-  for (const [tabId, tab] of tabs.entries()) {
-    if (tab.type === 'comparison' && tab.comparisonId === comparison.id) {
-      const updatedTab: ComparisonTab = {
-        ...tab,
-        viewingResults: false,
-        comparisonResultsTable: null,
-        lastExecutionTime: null,
-      };
-      newTabs.set(tabId, updatedTab);
-      updatedTabIds.push(tabId);
-    }
-  }
-
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-      tabs: newTabs,
-    },
-    undefined,
-    'AppStore/clearComparisonResults',
-  );
+  const clearResult = clearComparisonResultsInStore(comparison.id);
+  if (!clearResult) return;
+  const { comparison: updatedComparison, tabIds: updatedTabIds } = clearResult;
 
   if (iDbConn) {
     const tx = iDbConn.transaction([COMPARISON_TABLE_NAME, TAB_TABLE_NAME], 'readwrite');
     await tx.objectStore(COMPARISON_TABLE_NAME).put(updatedComparison, comparison.id);
     const tabStore = tx.objectStore(TAB_TABLE_NAME);
+    const { tabs: newTabs } = useAppStore.getState();
     for (const tabId of updatedTabIds) {
       const tab = newTabs.get(tabId);
       if (tab) {
@@ -210,24 +164,8 @@ export const updateComparisonSchemaAnalysis = (
   // Check if the comparison exists
   const comparison = ensureComparison(comparisonOrId, comparisons);
 
-  // Create updated comparison
-  const updatedComparison: Comparison = {
-    ...comparison,
-    schemaComparison,
-  };
-
-  // Update the store
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-    },
-    undefined,
-    'AppStore/updateComparisonSchemaAnalysis',
-  );
+  const updatedComparison = updateComparisonSchemaAnalysisInStore(comparison.id, schemaComparison);
+  if (!updatedComparison) return;
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -254,24 +192,8 @@ export const renameComparison = (
 
   const uniqueName = findUniqueName(newName, (value) => allExistingNames.has(value));
 
-  // Create updated comparison
-  const updatedComparison: Comparison = {
-    ...comparison,
-    name: uniqueName,
-  };
-
-  // Update the store
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-    },
-    undefined,
-    'AppStore/renameComparison',
-  );
+  const updatedComparison = renameComparisonInStore(comparison.id, uniqueName);
+  if (!updatedComparison) return;
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -289,25 +211,8 @@ export const updateComparisonExecutionTime = (
   // Check if the comparison exists
   const comparison = ensureComparison(comparisonOrId, comparisons);
 
-  // Create updated comparison
-  const updatedComparison: Comparison = {
-    ...comparison,
-    lastExecutionTime: timestamp,
-    lastRunAt: new Date().toISOString(),
-  };
-
-  // Update the store
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-    },
-    undefined,
-    'AppStore/updateComparisonExecutionTime',
-  );
+  const updatedComparison = updateComparisonExecutionTimeInStore(comparison.id, timestamp);
+  if (!updatedComparison) return;
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -325,24 +230,8 @@ export const updateComparisonResultsTable = (
   // Check if the comparison exists
   const comparison = ensureComparison(comparisonOrId, comparisons);
 
-  // Create updated comparison
-  const updatedComparison: Comparison = {
-    ...comparison,
-    resultsTableName,
-  };
-
-  // Update the store
-  const newComparisons = new Map(comparisons);
-  newComparisons.set(comparison.id, updatedComparison);
-
-  // Update the store with changes
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-    },
-    undefined,
-    'AppStore/updateComparisonResultsTable',
-  );
+  const updatedComparison = updateComparisonResultsTableInStore(comparison.id, resultsTableName);
+  if (!updatedComparison) return;
 
   // Persist the changes to IndexedDB
   const iDb = useAppStore.getState()._iDbConn;
@@ -369,14 +258,7 @@ export const deleteComparisons = async (
   comparisonIds: Iterable<ComparisonId>,
   pool?: any, // AsyncDuckDBConnectionPool - optional to avoid circular dependency
 ) => {
-  const {
-    comparisons,
-    tabs,
-    tabOrder,
-    activeTabId,
-    previewTabId,
-    _iDbConn: iDbConn,
-  } = useAppStore.getState();
+  const { comparisons, _iDbConn: iDbConn } = useAppStore.getState();
 
   const comparisonIdsToDeleteSet = new Set(comparisonIds);
 
@@ -389,49 +271,12 @@ export const deleteComparisons = async (
     }
   }
 
-  const newComparisons = deleteComparisonImpl(comparisonIds, comparisons);
-
-  const tabsToDelete: TabId[] = [];
-
-  for (const [tabId, tab] of tabs.entries()) {
-    if (tab.type === 'comparison') {
-      if (comparisonIdsToDeleteSet.has(tab.comparisonId)) {
-        tabsToDelete.push(tabId);
-      }
-    }
-  }
-
-  let newTabs = tabs;
-  let newTabOrder = tabOrder;
-  let newActiveTabId = activeTabId;
-  let newPreviewTabId = previewTabId;
-
-  if (tabsToDelete.length > 0) {
-    const result = deleteTabImpl({
-      deleteTabIds: tabsToDelete,
-      tabs,
-      tabOrder,
-      activeTabId,
-      previewTabId,
-    });
-
-    newTabs = result.newTabs;
-    newTabOrder = result.newTabOrder;
-    newActiveTabId = result.newActiveTabId;
-    newPreviewTabId = result.newPreviewTabId;
-  }
-
-  useAppStore.setState(
-    {
-      comparisons: newComparisons,
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-      activeTabId: newActiveTabId,
-      previewTabId: newPreviewTabId,
-    },
-    undefined,
-    'AppStore/deleteComparison',
-  );
+  const {
+    activeTabId: newActiveTabId,
+    previewTabId: newPreviewTabId,
+    tabOrder: newTabOrder,
+    tabIds: tabsToDelete,
+  } = deleteComparisonsInStore(comparisonIdsToDeleteSet);
 
   // Clean up results tables from the database
   if (pool) {

--- a/src/controllers/tab/comparison-tab-controller.ts
+++ b/src/controllers/tab/comparison-tab-controller.ts
@@ -15,7 +15,13 @@ import {
 } from '@models/comparison';
 import { TAB_TABLE_NAME } from '@models/persisted-store';
 import { ComparisonTab, TabId } from '@models/tab';
-import { useAppStore } from '@store/app-store';
+import {
+  createTabFromComparison as createTabFromComparisonInStore,
+  setComparisonExecutionTime as setComparisonExecutionTimeInStore,
+  setComparisonResultsTable as setComparisonResultsTableInStore,
+  setComparisonViewingResults as setComparisonViewingResultsInStore,
+  useAppStore,
+} from '@store/app-store';
 import { ensureComparison } from '@utils/comparison';
 import { makeTabId } from '@utils/tab';
 
@@ -148,19 +154,9 @@ export const getOrCreateTabFromComparison = (
     dataViewStateCache: null,
   };
 
-  // Add the new tab to the store
-  const newTabs = new Map(state.tabs).set(tabId, tab);
-  const newTabOrder = [...state.tabOrder, tabId];
-  const newActiveTabId = setActive ? tabId : state.activeTabId;
-
-  useAppStore.setState(
-    {
-      activeTabId: newActiveTabId,
-      tabs: newTabs,
-      tabOrder: newTabOrder,
-    },
-    undefined,
-    'AppStore/createTabFromComparison',
+  const { activeTabId: newActiveTabId, tabOrder: newTabOrder } = createTabFromComparisonInStore(
+    tab,
+    setActive ? tabId : undefined,
   );
 
   // Persist the new tab to IndexedDB
@@ -225,14 +221,8 @@ export const setComparisonViewingResults = (tabId: TabId, viewingResults: boolea
     return;
   }
 
-  const updatedTab: ComparisonTab = {
-    ...tab,
-    viewingResults,
-  };
-
-  const newTabs = new Map(state.tabs).set(tabId, updatedTab);
-
-  useAppStore.setState({ tabs: newTabs }, undefined, 'AppStore/setComparisonViewingResults');
+  const updatedTab = setComparisonViewingResultsInStore(tabId, viewingResults);
+  if (!updatedTab) return;
 
   // Persist the changes to IndexedDB
   const iDb = state._iDbConn;
@@ -257,14 +247,8 @@ export const setComparisonExecutionTime = (tabId: TabId, timestamp: number): voi
   updateComparisonExecutionTimeInternal(tab.comparisonId, timestamp);
 
   // Update the tab (UI state)
-  const updatedTab: ComparisonTab = {
-    ...tab,
-    lastExecutionTime: timestamp,
-  };
-
-  const newTabs = new Map(state.tabs).set(tabId, updatedTab);
-
-  useAppStore.setState({ tabs: newTabs }, undefined, 'AppStore/setComparisonExecutionTime');
+  const updatedTab = setComparisonExecutionTimeInStore(tabId, timestamp);
+  if (!updatedTab) return;
 
   // Persist the tab changes to IndexedDB
   const iDb = state._iDbConn;
@@ -293,14 +277,8 @@ export const setComparisonResultsTable = (
   updateComparisonResultsTableInternal(tab.comparisonId, comparisonResultsTable);
 
   // Update the tab (UI state)
-  const updatedTab: ComparisonTab = {
-    ...tab,
-    comparisonResultsTable,
-  };
-
-  const newTabs = new Map(state.tabs).set(tabId, updatedTab);
-
-  useAppStore.setState({ tabs: newTabs }, undefined, 'AppStore/setComparisonResultsTable');
+  const updatedTab = setComparisonResultsTableInStore(tabId, comparisonResultsTable);
+  if (!updatedTab) return;
 
   // Persist the tab changes to IndexedDB
   const iDb = state._iDbConn;

--- a/src/features/comparison/hooks/use-comparison-source-selection.ts
+++ b/src/features/comparison/hooks/use-comparison-source-selection.ts
@@ -1,7 +1,10 @@
 import { spotlight } from '@mantine/spotlight';
 import { AnyDataSource } from '@models/data-source';
 import { ComparisonSource } from '@models/tab';
-import { useAppStore } from '@store/app-store';
+import {
+  clearComparisonSourceSelectionCallback,
+  startComparisonSourceSelection,
+} from '@store/app-store';
 import { useCallback, useState } from 'react';
 
 import { dataSourceToComparisonSource } from '../utils/source-selection';
@@ -63,14 +66,11 @@ export function useComparisonSourceSelection(
 
       // Clear the selection target and callback
       setSelectionTarget(null);
-      useAppStore.setState({ comparisonSourceSelectionCallback: null });
+      clearComparisonSourceSelectionCallback();
     };
 
     // Store the callback in app store BEFORE opening spotlight
-    useAppStore.setState({
-      comparisonSourceSelectionCallback: callback,
-      spotlightView: 'dataSources',
-    });
+    startComparisonSourceSelection(callback);
 
     spotlight.open();
   }, [onSourceAChange]);
@@ -95,14 +95,11 @@ export function useComparisonSourceSelection(
 
       // Clear the selection target and callback
       setSelectionTarget(null);
-      useAppStore.setState({ comparisonSourceSelectionCallback: null });
+      clearComparisonSourceSelectionCallback();
     };
 
     // Store the callback in app store BEFORE opening spotlight
-    useAppStore.setState({
-      comparisonSourceSelectionCallback: callback,
-      spotlightView: 'dataSources',
-    });
+    startComparisonSourceSelection(callback);
 
     spotlight.open();
   }, [onSourceBChange]);

--- a/src/store/app-store.tsx
+++ b/src/store/app-store.tsx
@@ -1,8 +1,15 @@
 import { IconType } from '@components/named-icon';
+import { deleteComparisonImpl } from '@controllers/comparison/pure';
 import { persistPutSqlScriptSession } from '@controllers/sql-script/persist';
 import { deleteTabImpl } from '@controllers/tab/pure';
 import { PROGRESS_CLEANUP_MAX_AGE_MS } from '@features/comparison/config/execution-config';
-import { Comparison, ComparisonExecutionProgress, ComparisonId } from '@models/comparison';
+import {
+  Comparison,
+  ComparisonConfig,
+  ComparisonExecutionProgress,
+  ComparisonId,
+  SchemaComparisonResult,
+} from '@models/comparison';
 import { ContentViewState } from '@models/content-view';
 import {
   AnyDataSource,
@@ -21,7 +28,7 @@ import { ExportFormat } from '@models/export-options';
 import { LocalEntry, LocalEntryId, LocalFile } from '@models/file-system';
 import { AppIdbSchema } from '@models/persisted-store';
 import { SQLScript, SQLScriptId, SQLScriptSession } from '@models/sql-script';
-import { AnyTab, ScriptTab, TabId, TabReactiveState, TabType } from '@models/tab';
+import { AnyTab, ComparisonTab, ScriptTab, TabId, TabReactiveState, TabType } from '@models/tab';
 import { getDatabaseIdentifier, isFlatFileDataSource } from '@utils/data-source';
 import { getTabIcon, getTabName } from '@utils/navigation';
 import { IDBPDatabase } from 'idb';
@@ -33,7 +40,7 @@ import { resetAppData } from './restore';
 import { createSelectors } from './utils';
 import { SpotlightView } from '../components/spotlight/model';
 import type { TabExecutionError } from '../controllers/tab/tab-controller';
-import { SourceSelectionCallback } from '../features/comparison/hooks/use-comparison-source-selection';
+import type { SourceSelectionCallback } from '../features/comparison/hooks/use-comparison-source-selection';
 
 type AppLoadState = 'init' | 'core-ready' | 'ready' | 'error';
 
@@ -687,6 +694,297 @@ export function useTabHasError(tabId: TabId): boolean {
 export function useTabExecutionErrorsMap(): Map<TabId, TabExecutionError> {
   return useAppStore(useShallow((state) => new Map(state.tabExecutionErrors)));
 }
+
+const updateComparisonInternal = (
+  comparisonId: ComparisonId,
+  updater: (comparison: Comparison) => Comparison,
+  action: string,
+): Comparison | null => {
+  let updatedComparison: Comparison | null = null;
+
+  useAppStore.setState(
+    (state) => {
+      const comparison = state.comparisons.get(comparisonId);
+      if (!comparison) return state;
+
+      updatedComparison = updater(comparison);
+      const comparisons = new Map(state.comparisons);
+      comparisons.set(comparisonId, updatedComparison);
+
+      return { comparisons };
+    },
+    undefined,
+    action,
+  );
+
+  return updatedComparison;
+};
+
+const updateComparisonTabInternal = (
+  tabId: TabId,
+  updater: (tab: ComparisonTab) => ComparisonTab,
+  action: string,
+): ComparisonTab | null => {
+  let updatedTab: ComparisonTab | null = null;
+
+  useAppStore.setState(
+    (state) => {
+      const tab = state.tabs.get(tabId);
+      if (!tab || tab.type !== 'comparison') return state;
+
+      updatedTab = updater(tab);
+      const tabs = new Map(state.tabs);
+      tabs.set(tabId, updatedTab);
+
+      return { tabs };
+    },
+    undefined,
+    action,
+  );
+
+  return updatedTab;
+};
+
+export const createComparison = (comparison: Comparison): void => {
+  useAppStore.setState(
+    (state) => ({
+      comparisons: new Map(state.comparisons).set(comparison.id, comparison),
+    }),
+    undefined,
+    'AppStore/createComparison',
+  );
+};
+
+export const updateComparisonConfig = (
+  comparisonId: ComparisonId,
+  config: ComparisonConfig,
+): Comparison | null =>
+  updateComparisonInternal(
+    comparisonId,
+    (comparison) => ({ ...comparison, config }),
+    'AppStore/updateComparisonConfig',
+  );
+
+export const clearComparisonResults = (
+  comparisonId: ComparisonId,
+): { comparison: Comparison; tabIds: TabId[] } | null => {
+  let result: { comparison: Comparison; tabIds: TabId[] } | null = null;
+
+  useAppStore.setState(
+    (state) => {
+      const comparison = state.comparisons.get(comparisonId);
+      if (!comparison) return state;
+
+      const updatedComparison: Comparison = {
+        ...comparison,
+        resultsTableName: null,
+        lastExecutionTime: null,
+        lastRunAt: null,
+      };
+      const comparisons = new Map(state.comparisons);
+      comparisons.set(comparisonId, updatedComparison);
+
+      const tabs = new Map(state.tabs);
+      const tabIds: TabId[] = [];
+
+      for (const [tabId, tab] of state.tabs.entries()) {
+        if (tab.type === 'comparison' && tab.comparisonId === comparisonId) {
+          const updatedTab: ComparisonTab = {
+            ...tab,
+            viewingResults: false,
+            comparisonResultsTable: null,
+            lastExecutionTime: null,
+          };
+          tabs.set(tabId, updatedTab);
+          tabIds.push(tabId);
+        }
+      }
+
+      result = { comparison: updatedComparison, tabIds };
+
+      return { comparisons, tabs };
+    },
+    undefined,
+    'AppStore/clearComparisonResults',
+  );
+
+  return result;
+};
+
+export const updateComparisonSchemaAnalysis = (
+  comparisonId: ComparisonId,
+  schemaComparison: SchemaComparisonResult | null,
+): Comparison | null =>
+  updateComparisonInternal(
+    comparisonId,
+    (comparison) => ({ ...comparison, schemaComparison }),
+    'AppStore/updateComparisonSchemaAnalysis',
+  );
+
+export const renameComparison = (comparisonId: ComparisonId, name: string): Comparison | null =>
+  updateComparisonInternal(
+    comparisonId,
+    (comparison) => ({ ...comparison, name }),
+    'AppStore/renameComparison',
+  );
+
+export const updateComparisonExecutionTime = (
+  comparisonId: ComparisonId,
+  timestamp: number,
+): Comparison | null =>
+  updateComparisonInternal(
+    comparisonId,
+    (comparison) => ({
+      ...comparison,
+      lastExecutionTime: timestamp,
+      lastRunAt: new Date().toISOString(),
+    }),
+    'AppStore/updateComparisonExecutionTime',
+  );
+
+export const updateComparisonResultsTable = (
+  comparisonId: ComparisonId,
+  resultsTableName: string | null,
+): Comparison | null =>
+  updateComparisonInternal(
+    comparisonId,
+    (comparison) => ({ ...comparison, resultsTableName }),
+    'AppStore/updateComparisonResultsTable',
+  );
+
+export const deleteComparisons = (
+  comparisonIds: Iterable<ComparisonId>,
+): CloseTabsResult & { tabIds: TabId[] } => {
+  let result: CloseTabsResult & { tabIds: TabId[] } = {
+    activeTabId: null,
+    previewTabId: null,
+    tabOrder: [],
+    tabIds: [],
+  };
+
+  useAppStore.setState(
+    (state) => {
+      const comparisonIdsToDeleteSet = new Set(comparisonIds);
+      const comparisons = deleteComparisonImpl(comparisonIdsToDeleteSet, state.comparisons);
+      const tabIds: TabId[] = [];
+
+      for (const [tabId, tab] of state.tabs.entries()) {
+        if (tab.type === 'comparison' && comparisonIdsToDeleteSet.has(tab.comparisonId)) {
+          tabIds.push(tabId);
+        }
+      }
+
+      let tabs = state.tabs;
+      let tabOrder = state.tabOrder;
+      let activeTabId = state.activeTabId;
+      let previewTabId = state.previewTabId;
+
+      if (tabIds.length > 0) {
+        const next = deleteTabImpl({
+          deleteTabIds: tabIds,
+          tabs: state.tabs,
+          tabOrder: state.tabOrder,
+          activeTabId: state.activeTabId,
+          previewTabId: state.previewTabId,
+        });
+
+        tabs = next.newTabs;
+        tabOrder = next.newTabOrder;
+        activeTabId = next.newActiveTabId;
+        previewTabId = next.newPreviewTabId;
+      }
+
+      result = { activeTabId, previewTabId, tabOrder, tabIds };
+
+      return {
+        comparisons,
+        tabs,
+        tabOrder,
+        activeTabId,
+        previewTabId,
+      };
+    },
+    undefined,
+    'AppStore/deleteComparison',
+  );
+
+  return result;
+};
+
+export const createTabFromComparison = (
+  tab: ComparisonTab,
+  activeTabId?: TabId | null,
+): { activeTabId: TabId | null; tabOrder: TabId[] } => {
+  let result: { activeTabId: TabId | null; tabOrder: TabId[] } = {
+    activeTabId: null,
+    tabOrder: [],
+  };
+
+  useAppStore.setState(
+    (state) => {
+      const tabs = new Map(state.tabs).set(tab.id, tab);
+      const tabOrder = [...state.tabOrder, tab.id];
+      const nextActiveTabId = activeTabId === undefined ? state.activeTabId : activeTabId;
+      result = { activeTabId: nextActiveTabId, tabOrder };
+
+      return {
+        activeTabId: nextActiveTabId,
+        tabs,
+        tabOrder,
+      };
+    },
+    undefined,
+    'AppStore/createTabFromComparison',
+  );
+
+  return result;
+};
+
+export const setComparisonViewingResults = (
+  tabId: TabId,
+  viewingResults: boolean,
+): ComparisonTab | null =>
+  updateComparisonTabInternal(
+    tabId,
+    (tab) => ({ ...tab, viewingResults }),
+    'AppStore/setComparisonViewingResults',
+  );
+
+export const setComparisonExecutionTime = (tabId: TabId, timestamp: number): ComparisonTab | null =>
+  updateComparisonTabInternal(
+    tabId,
+    (tab) => ({ ...tab, lastExecutionTime: timestamp }),
+    'AppStore/setComparisonExecutionTime',
+  );
+
+export const setComparisonResultsTable = (
+  tabId: TabId,
+  comparisonResultsTable: string | null,
+): ComparisonTab | null =>
+  updateComparisonTabInternal(
+    tabId,
+    (tab) => ({ ...tab, comparisonResultsTable }),
+    'AppStore/setComparisonResultsTable',
+  );
+
+export const startComparisonSourceSelection = (callback: SourceSelectionCallback): void => {
+  useAppStore.setState(
+    {
+      comparisonSourceSelectionCallback: callback,
+      spotlightView: 'dataSources',
+    },
+    undefined,
+    'AppStore/startComparisonSourceSelection',
+  );
+};
+
+export const clearComparisonSourceSelectionCallback = (): void => {
+  useAppStore.setState(
+    { comparisonSourceSelectionCallback: null },
+    undefined,
+    'AppStore/clearComparisonSourceSelectionCallback',
+  );
+};
 
 // Simple actions / setters that are not "big" enough to go to controllers
 export const setAppLoadState = (appState: AppLoadState) => {

--- a/tests/unit/store/comparison-actions.test.ts
+++ b/tests/unit/store/comparison-actions.test.ts
@@ -1,0 +1,192 @@
+import type { SourceSelectionCallback } from '@features/comparison/hooks/use-comparison-source-selection';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { Comparison, ComparisonId } from '@models/comparison';
+import { ComparisonTab, TabId } from '@models/tab';
+import {
+  clearComparisonResults,
+  clearComparisonSourceSelectionCallback,
+  deleteComparisons,
+  startComparisonSourceSelection,
+  useAppStore,
+} from '@store/app-store';
+
+const comparison = (id: string, overrides: Partial<Comparison> = {}): Comparison => ({
+  id: id as ComparisonId,
+  name: id,
+  config: null,
+  schemaComparison: null,
+  lastExecutionTime: null,
+  lastRunAt: null,
+  resultsTableName: null,
+  metadata: {
+    sourceStats: null,
+    partialResults: false,
+    executionMetadata: null,
+  },
+  ...overrides,
+});
+
+const comparisonTab = (
+  id: string,
+  comparisonId: ComparisonId,
+  overrides: Partial<ComparisonTab> = {},
+): ComparisonTab => ({
+  id: id as TabId,
+  type: 'comparison',
+  comparisonId,
+  viewingResults: false,
+  lastExecutionTime: null,
+  comparisonResultsTable: null,
+  dataViewStateCache: null,
+  ...overrides,
+});
+
+describe('comparison store actions', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      comparisons: new Map(),
+      tabs: new Map(),
+      tabOrder: [],
+      activeTabId: null,
+      previewTabId: null,
+      comparisonSourceSelectionCallback: null,
+      spotlightView: 'home',
+    });
+  });
+
+  it('clears comparison results and cascades result state to comparison tabs', () => {
+    const target = comparison('target', {
+      resultsTableName: '__pondpilot_comparison_target',
+      lastExecutionTime: 12,
+      lastRunAt: '2026-07-11T10:00:00.000Z',
+    });
+    const other = comparison('other', {
+      resultsTableName: '__pondpilot_comparison_other',
+      lastExecutionTime: 3,
+    });
+    const targetTab = comparisonTab('target-tab', target.id, {
+      viewingResults: true,
+      comparisonResultsTable: target.resultsTableName,
+      lastExecutionTime: target.lastExecutionTime,
+    });
+    const secondTargetTab = comparisonTab('second-target-tab', target.id, {
+      viewingResults: true,
+      comparisonResultsTable: target.resultsTableName,
+      lastExecutionTime: target.lastExecutionTime,
+    });
+    const otherTab = comparisonTab('other-tab', other.id, {
+      viewingResults: true,
+      comparisonResultsTable: other.resultsTableName,
+      lastExecutionTime: other.lastExecutionTime,
+    });
+    const originalComparisons = new Map([
+      [target.id, target],
+      [other.id, other],
+    ]);
+    const originalTabs = new Map([
+      [targetTab.id, targetTab],
+      [secondTargetTab.id, secondTargetTab],
+      [otherTab.id, otherTab],
+    ]);
+
+    useAppStore.setState({
+      comparisons: originalComparisons,
+      tabs: originalTabs,
+      tabOrder: [targetTab.id, secondTargetTab.id, otherTab.id],
+    });
+
+    const result = clearComparisonResults(target.id);
+    const state = useAppStore.getState();
+
+    expect(result).toEqual({
+      comparison: {
+        ...target,
+        resultsTableName: null,
+        lastExecutionTime: null,
+        lastRunAt: null,
+      },
+      tabIds: [targetTab.id, secondTargetTab.id],
+    });
+    expect(state.comparisons).not.toBe(originalComparisons);
+    expect(state.tabs).not.toBe(originalTabs);
+    expect(state.comparisons.get(target.id)).toMatchObject({
+      resultsTableName: null,
+      lastExecutionTime: null,
+      lastRunAt: null,
+    });
+    expect(state.tabs.get(targetTab.id)).toMatchObject({
+      viewingResults: false,
+      comparisonResultsTable: null,
+      lastExecutionTime: null,
+    });
+    expect(state.tabs.get(secondTargetTab.id)).toMatchObject({
+      viewingResults: false,
+      comparisonResultsTable: null,
+      lastExecutionTime: null,
+    });
+    expect(state.comparisons.get(other.id)).toBe(other);
+    expect(state.tabs.get(otherTab.id)).toBe(otherTab);
+    expect(originalComparisons.get(target.id)).toBe(target);
+    expect(originalTabs.get(targetTab.id)).toBe(targetTab);
+  });
+
+  it('deletes comparisons and associated tabs while updating active, preview, and order state', () => {
+    const firstComparison = comparison('first');
+    const closingComparison = comparison('closing');
+    const lastComparison = comparison('last');
+    const firstTab = comparisonTab('first-tab', firstComparison.id);
+    const closingTab = comparisonTab('closing-tab', closingComparison.id);
+    const lastTab = comparisonTab('last-tab', lastComparison.id);
+    const originalComparisons = new Map([
+      [firstComparison.id, firstComparison],
+      [closingComparison.id, closingComparison],
+      [lastComparison.id, lastComparison],
+    ]);
+    const originalTabs = new Map([
+      [firstTab.id, firstTab],
+      [closingTab.id, closingTab],
+      [lastTab.id, lastTab],
+    ]);
+
+    useAppStore.setState({
+      comparisons: originalComparisons,
+      tabs: originalTabs,
+      tabOrder: [firstTab.id, closingTab.id, lastTab.id],
+      activeTabId: closingTab.id,
+      previewTabId: closingTab.id,
+    });
+
+    const result = deleteComparisons([closingComparison.id]);
+    const state = useAppStore.getState();
+
+    expect(result).toEqual({
+      activeTabId: firstTab.id,
+      previewTabId: null,
+      tabOrder: [firstTab.id, lastTab.id],
+      tabIds: [closingTab.id],
+    });
+    expect(state.comparisons).not.toBe(originalComparisons);
+    expect(state.tabs).not.toBe(originalTabs);
+    expect(Array.from(state.comparisons.keys())).toEqual([firstComparison.id, lastComparison.id]);
+    expect(Array.from(state.tabs.keys())).toEqual([firstTab.id, lastTab.id]);
+    expect(state.tabOrder).toEqual([firstTab.id, lastTab.id]);
+    expect(state.activeTabId).toBe(firstTab.id);
+    expect(state.previewTabId).toBeNull();
+    expect(originalComparisons.has(closingComparison.id)).toBe(true);
+    expect(originalTabs.has(closingTab.id)).toBe(true);
+  });
+
+  it('sets and clears comparison source-selection callback state', () => {
+    const callback: SourceSelectionCallback = () => undefined;
+
+    startComparisonSourceSelection(callback);
+
+    expect(useAppStore.getState().comparisonSourceSelectionCallback).toBe(callback);
+    expect(useAppStore.getState().spotlightView).toBe('dataSources');
+
+    clearComparisonSourceSelectionCallback();
+
+    expect(useAppStore.getState().comparisonSourceSelectionCallback).toBeNull();
+    expect(useAppStore.getState().spotlightView).toBe('dataSources');
+  });
+});


### PR DESCRIPTION
Second increment of the store-actions migration, following #331's pattern exactly.

## Comparison domain
14 named actions extracted from raw `setState` sites in `comparison-controller.ts` (8), `comparison-tab-controller.ts` (4), and `use-comparison-source-selection.ts` (2 grouped). `use-comparison-execution` already used named wrappers — left alone; `table-utils` had no raw writes.

Cascade/transient-state behavior pinned in `tests/unit/store/comparison-actions.test.ts`.

## Gates
All exit 0: typecheck · unit+coverage (82.26% branches) · eslint 0 errors · prettier · build + budget · `--immutable`. Comparison integration specs ride on CI.

Remaining raw-setState domains for future increments: data-source/iceberg/motherduck/quack utils (~the rest of the audit's 106).