### PR TITLE
fix(quack): prevent stale WASM catalog errors

### DIFF
--- a/src/models/bug-report.ts
+++ b/src/models/bug-report.ts
@@ -62,7 +62,7 @@ export interface BugReportContext {
   dataSources: Array<{
     id: string;
     type: string;
-    connectionStatus?: string;
+    connectionState?: string;
   }>;
 }
 

--- a/src/utils/bug-report-context.ts
+++ b/src/utils/bug-report-context.ts
@@ -1,6 +1,7 @@
 import type { FeatureContextType } from '@features/feature-context';
 import type { BugReportContext } from '@models/bug-report';
 import { useAppStore } from '@store/app-store';
+import { getViteEnv } from '@utils/env';
 import { isMobileDevice } from '@utils/is-mobile-device';
 
 declare const __VERSION__: string;
@@ -30,7 +31,7 @@ export function captureBugReportContext(featureContext: FeatureContextType): Bug
       platform: navigator.platform,
       language: navigator.language,
       viewport: `${window.innerWidth}x${window.innerHeight}`,
-      isDevelopment: import.meta.env.DEV,
+      isDevelopment: getViteEnv().DEV,
       isIntegrationTest: typeof __INTEGRATION_TEST__ !== 'undefined' ? __INTEGRATION_TEST__ : false,
     },
     browserFeatures: {
@@ -54,7 +55,7 @@ export function captureBugReportContext(featureContext: FeatureContextType): Bug
     dataSources: Array.from(store.dataSources.values()).map((ds) => ({
       id: ds.id,
       type: ds.type,
-      connectionStatus: 'connectionStatus' in ds ? (ds.connectionStatus as string) : undefined,
+      connectionState: 'connectionState' in ds ? (ds.connectionState as string) : undefined,
     })),
   };
 }
@@ -80,6 +81,15 @@ export function formatContextForSlack(context: BugReportContext): string {
   lines.push(`• Data Sources: ${context.appState.totalDataSources}`);
   lines.push(`• Scripts: ${context.appState.totalScripts}`);
   lines.push('');
+
+  if (context.dataSources.length > 0) {
+    lines.push('*Data Sources:*');
+    context.dataSources.forEach((dataSource) => {
+      const state = dataSource.connectionState ? ` (${dataSource.connectionState})` : '';
+      lines.push(`• ${dataSource.type}${state}`);
+    });
+    lines.push('');
+  }
 
   if (context.errors.totalTabsWithErrors > 0) {
     lines.push('*Errors:*');

--- a/src/utils/quack.ts
+++ b/src/utils/quack.ts
@@ -55,6 +55,8 @@ export function buildAttachQuackQuery(
 }
 
 const QUACK_QUERY_TIMEOUT_MS = 20_000;
+const PATCHED_QUACK_WASM_EXTENSION_URL =
+  'https://nightly-extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm';
 
 async function queryQuackWithTimeout<T>(query: Promise<T>, operation: string): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -89,11 +91,10 @@ const getQuackWasmExtensionUrls = (): string[] => {
 
   return [
     ...(configuredUrl ? [configuredUrl] : []),
-    // The official v1.5.2 artifact contains the full Quack extension symbols.
-    // It is kept as a direct-load fallback for newer DuckDB-WASM builds and as a
-    // storage-support retry when repository-loaded artifacts only expose helper
-    // functions without registering the Quack ATTACH storage type.
-    'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm',
+    // The official v1.5.2 artifact predates duckdb/duckdb-quack#143 and throws
+    // from QuackCatalog::InMemory/GetDBPath when DuckDB inspects attached
+    // databases. Use the patched v1.5.2 nightly artifact instead.
+    PATCHED_QUACK_WASM_EXTENSION_URL,
   ];
 };
 
@@ -159,9 +160,9 @@ async function tryLoadQuackFromRepositories(
 }
 
 export async function loadQuackExtension(pool: AsyncDuckDBConnectionPool): Promise<void> {
-  const repositoryResult = await tryLoadQuackFromRepositories(pool);
-  if (repositoryResult.loaded) return;
-
+  // Prefer the known-compatible artifact. A repository install may resolve to
+  // an older cached Quack build that attaches successfully but later breaks
+  // duckdb_databases() with "InMemory not implemented yet".
   const pinnedResult = await tryLoadQuackFromPinnedWasm(pool);
   if (pinnedResult.loaded) {
     try {
@@ -180,11 +181,14 @@ export async function loadQuackExtension(pool: AsyncDuckDBConnectionPool): Promi
     return;
   }
 
+  const repositoryResult = await tryLoadQuackFromRepositories(pool);
+  if (repositoryResult.loaded) return;
+
   throw new Error(
     'The current DuckDB-WASM bundle cannot load the Quack extension yet. ' +
       'Upgrade DuckDB-WASM to a build that ships Quack support. ' +
-      `Repository errors: ${repositoryResult.error}. ` +
-      `Pinned WASM extension fallbacks failed: ${pinnedResult.error}`,
+      `Patched WASM extension fallbacks failed: ${pinnedResult.error}. ` +
+      `Repository errors: ${repositoryResult.error}`,
   );
 }
 

--- a/tests/unit/utils/bug-report-context.test.ts
+++ b/tests/unit/utils/bug-report-context.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+import type { BugReportContext } from '@models/bug-report';
+import { formatContextForSlack } from '@utils/bug-report-context';
+
+const makeContext = (): BugReportContext => ({
+  appVersion: 'v0.10.0',
+  timestamp: '2026-08-02T12:00:00.000Z',
+  environment: {
+    userAgent: 'Test Browser',
+    platform: 'Test Platform',
+    language: 'en',
+    viewport: '984x780',
+    isDevelopment: false,
+    isIntegrationTest: false,
+  },
+  browserFeatures: {
+    hasFileSystemAccess: true,
+    isOPFSSupported: true,
+    isMobileDevice: false,
+    hasDragAndDrop: true,
+  },
+  appState: {
+    loadState: 'ready',
+    activeTabId: 'tab-1',
+    totalTabs: 2,
+    totalDataSources: 2,
+    totalScripts: 2,
+  },
+  errors: {
+    activeTabError: 'Not implemented Error: InMemory not implemented yet',
+    totalTabsWithErrors: 1,
+    recentErrors: [],
+  },
+  dataSources: [
+    { id: 'source-1', type: 'quack', connectionState: 'connected' },
+    { id: 'source-2', type: 'csv' },
+  ],
+});
+
+describe('bug report context formatting', () => {
+  it('includes safe data-source types and connection states without source identifiers', () => {
+    const formatted = formatContextForSlack(makeContext());
+
+    expect(formatted).toContain('*Data Sources:*');
+    expect(formatted).toContain('• quack (connected)');
+    expect(formatted).toContain('• csv');
+    expect(formatted).not.toContain('source-1');
+    expect(formatted).not.toContain('source-2');
+  });
+});

--- a/tests/unit/utils/quack.test.ts
+++ b/tests/unit/utils/quack.test.ts
@@ -44,44 +44,40 @@ describe('quack utils', () => {
     );
   });
 
-  it('loads Quack from core nightly first', async () => {
+  it('loads the patched pinned Quack WASM artifact before repositories', async () => {
     const query = jest.fn<(sql: string) => Promise<unknown>>().mockResolvedValue({});
 
     await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
-    expect(query).toHaveBeenNthCalledWith(1, 'FORCE INSTALL quack FROM core_nightly');
-    expect(query).toHaveBeenLastCalledWith('LOAD quack');
-  });
-
-  it('tries community repositories when core nightly fails', async () => {
-    const query = jest
-      .fn<(sql: string) => Promise<unknown>>()
-      .mockRejectedValueOnce(new Error('core nightly failed'))
-      .mockRejectedValueOnce(new Error('core nightly failed'))
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
-
-    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
-    expect(query).toHaveBeenNthCalledWith(3, 'FORCE INSTALL quack FROM community');
-    expect(query).toHaveBeenLastCalledWith('LOAD quack');
-  });
-
-  it('falls back to pinned Quack WASM artifacts when repository loading fails', async () => {
-    const query = jest
-      .fn<(sql: string) => Promise<unknown>>()
-      .mockRejectedValueOnce(new Error('core nightly failed'))
-      .mockRejectedValueOnce(new Error('core nightly failed'))
-      .mockRejectedValueOnce(new Error('community failed'))
-      .mockRejectedValueOnce(new Error('community failed'))
-      .mockRejectedValueOnce(new Error('explicit community failed'))
-      .mockRejectedValueOnce(new Error('explicit community failed'))
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
-
-    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
     expect(query).toHaveBeenNthCalledWith(
-      7,
-      "LOAD 'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
+      1,
+      "LOAD 'https://nightly-extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
     );
+    expect(query).toHaveBeenLastCalledWith('LOAD quack');
+  });
+
+  it('falls back to extension repositories when the patched artifact fails', async () => {
+    const query = jest
+      .fn<(sql: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('patched artifact failed'))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+    expect(query).toHaveBeenNthCalledWith(2, 'FORCE INSTALL quack FROM core_nightly');
+    expect(query).toHaveBeenLastCalledWith('LOAD quack');
+  });
+
+  it('tries community repositories when the patched artifact and core nightly fail', async () => {
+    const query = jest
+      .fn<(sql: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('patched artifact failed'))
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockRejectedValueOnce(new Error('core nightly failed'))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
+    expect(query).toHaveBeenNthCalledWith(4, 'FORCE INSTALL quack FROM community');
     expect(query).toHaveBeenLastCalledWith('LOAD quack');
   });
 
@@ -91,20 +87,11 @@ describe('quack utils', () => {
     } = (globalThis as any).import;
     env.VITE_QUACK_WASM_EXTENSION_URL = '/duckdb-extensions/quack.duckdb_extension.wasm';
     try {
-      const query = jest
-        .fn<(sql: string) => Promise<unknown>>()
-        .mockRejectedValueOnce(new Error('core nightly failed'))
-        .mockRejectedValueOnce(new Error('core nightly failed'))
-        .mockRejectedValueOnce(new Error('community failed'))
-        .mockRejectedValueOnce(new Error('community failed'))
-        .mockRejectedValueOnce(new Error('explicit community failed'))
-        .mockRejectedValueOnce(new Error('explicit community failed'))
-        .mockResolvedValueOnce({})
-        .mockResolvedValueOnce({});
+      const query = jest.fn<(sql: string) => Promise<unknown>>().mockResolvedValue({});
 
       await expect(loadQuackExtension({ query } as any)).resolves.toBeUndefined();
       expect(query).toHaveBeenNthCalledWith(
-        7,
+        1,
         "LOAD '/duckdb-extensions/quack.duckdb_extension.wasm'",
       );
       expect(query).toHaveBeenLastCalledWith('LOAD quack');
@@ -113,7 +100,7 @@ describe('quack utils', () => {
     }
   });
 
-  it('retries with pinned Quack WASM artifacts when repository loading lacks ATTACH storage support', async () => {
+  it('retries with the patched Quack WASM artifact when ATTACH storage support is missing', async () => {
     const pool = {
       query: jest
         .fn<(sql: string) => Promise<unknown>>()
@@ -135,7 +122,7 @@ describe('quack utils', () => {
     ).resolves.toBeUndefined();
     expect(pool.query).toHaveBeenNthCalledWith(
       4,
-      "LOAD 'https://extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
+      "LOAD 'https://nightly-extensions.duckdb.org/v1.5.2/wasm_eh/quack.duckdb_extension.wasm'",
     );
   });
 


### PR DESCRIPTION
## Summary

- prefer the patched DuckDB 1.5.2 Quack WASM artifact before repository-installed builds
- keep the existing extension repositories as availability fallbacks
- include safe data-source type and connection-state details in anonymous bug reports
- cover the load order and diagnostic formatting with unit tests

## Why

The official Quack v1.5.2 WASM artifact predates [duckdb-quack#143](https://github.com/duckdb/duckdb-quack/pull/143). Its `QuackCatalog::InMemory()` and `GetDBPath()` implementations throw, so catalog inspection through `duckdb_databases()` can fail after a Quack database is attached with:

```text
Not implemented Error: InMemory not implemented yet
```

Loading the patched version first avoids selecting an older cached repository build. The repositories remain available if the direct artifact cannot be loaded.

The feedback payload previously checked a non-existent `connectionStatus` property and omitted data-source details from the Slack context. It now reports only the safe source type and connection state, without identifiers, URIs, names, queries, or credentials.

## Validation

- `yarn test:unit --runInBand` — 74 suites, 1190 tests passed
- `yarn typecheck`
- Prettier check for changed files
- ESLint for changed files

The local application, dev server, browser tests, and end-to-end tests were not run.
