### PR TITLE
Fix table widths after result schema changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-icons": "5.7.0",
     "react-is": "19.2.7",
     "react-markdown": "10.1.0",
-    "react-router": "7.18.1",
+    "react-router": "7.18.2",
     "reactflow": "11.11.4",
     "recharts": "3.9.2",
     "sql-formatter": "15.8.2",

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -99,9 +99,9 @@ export const Table = memo(
     });
 
     const { columnSizingInfo, columnSizing } = table.getState();
+    const headers = table.getFlatHeaders();
 
     const { columnSizeVars, colSizes } = useMemo(() => {
-      const headers = table.getFlatHeaders();
       const sizes: { [key: string]: number } = {};
       const sizeVars: { [key: string]: number } = {};
 
@@ -131,7 +131,7 @@ export const Table = memo(
 
       columnSizesRef.current = sizes;
       return { columnSizeVars: sizeVars, colSizes: sizes };
-    }, [columnSizing, columnSizingInfo, table]);
+    }, [columnSizing, columnSizingInfo, headers]);
 
     // Notify parent of column size changes after render (not during)
     useEffect(() => {

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -57,3 +57,46 @@ test('Header cell width matches data cell width for special character columns', 
     expect(headerBoundingBox?.width).toBeCloseTo(dataBoundingBox?.width as number, 1);
   }
 });
+
+test('Column widths update when the result schema expands in the same tab', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+
+  await fillScript('SELECT 1 AS initial_column;');
+  await runScript();
+  await waitForDataTable();
+
+  const columnNames = ['line_id', 'run_id', 'message'];
+  await fillScript(`
+    SELECT
+      21004 + i AS line_id,
+      48262306 AS run_id,
+      CASE
+        WHEN i < 4 THEN 'ok'
+        ELSE repeat('A long error message ', 50)
+      END AS message
+    FROM range(6) AS rows(i);
+  `);
+  await runScript();
+
+  const dataTable = await waitForDataTable();
+
+  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
+    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
+    const headerBoundingBox = await getHeaderCell(dataTable, columnId).boundingBox();
+
+    for (const rowIndex of [0, 4]) {
+      const dataBoundingBox = await getDataCellContainer(
+        dataTable,
+        columnId,
+        rowIndex,
+      ).boundingBox();
+
+      expect(dataBoundingBox?.width).toBeCloseTo(headerBoundingBox?.width as number, 1);
+    }
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,7 +10631,7 @@ __metadata:
     react-icons: "npm:5.7.0"
     react-is: "npm:19.2.7"
     react-markdown: "npm:10.1.0"
-    react-router: "npm:7.18.1"
+    react-router: "npm:7.18.2"
     reactflow: "npm:11.11.4"
     recharts: "npm:3.9.2"
     sql-formatter: "npm:15.8.2"
@@ -11082,9 +11082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.1":
-  version: 7.18.1
-  resolution: "react-router@npm:7.18.1"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -11094,7 +11094,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
+  checksum: 10c0/513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- recompute table width variables when the result's flat-header set changes
- add integration coverage for expanding a result schema in the same query tab
- verify long cell content remains aligned with headers and short rows
- update React Router from 7.18.1 to 7.18.2 to resolve GHSA-qwww-vcr4-c8h2

## Root cause

TanStack keeps the table instance stable while its column definitions change. The width-variable memo depended on that stable instance, so it could retain variables from the previous result schema. New columns then had invalid CSS width expressions and fell back to content-driven flex sizing on each row.

## CI follow-up

The initial `Lint` job failed in the production dependency audit, before ESLint ran. GitHub updated the advisory with React Router 7.18.2 as the patched release for the 7.x line, so this PR takes the minimal patch upgrade instead of ignoring the advisory or moving to React Router 8.

## Validation

- `yarn install --immutable`
- `yarn npm audit --environment production --severity high`
- `yarn build:test`
- `yarn typecheck`
- `yarn prettier`
- `yarn lint` (0 errors)
- `yarn test:unit --runInBand` (73 suites, 1189 tests)
- `PLAYWRIGHT_WORKERS=1 yarn test:no-build tests/integration/data-viewer/table-layout.spec.ts --project=chromium` (2 tests)
- browser QA: one-column result followed by a multi-column result with a long value; header and rows remained at matching widths