### PR TITLE
Strengthen table layout and truncation behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-icons": "5.7.0",
     "react-is": "19.2.7",
     "react-markdown": "10.1.0",
-    "react-router": "7.18.1",
+    "react-router": "7.18.2",
     "reactflow": "11.11.4",
     "recharts": "3.9.2",
     "sql-formatter": "15.8.2",

--- a/src/components/table/components/table-body/components/table-cell.tsx
+++ b/src/components/table/components/table-body/components/table-cell.tsx
@@ -7,7 +7,7 @@ import { copyToClipboard } from '@utils/clipboard';
 import { isNumberType, stringifyTypedValue } from '@utils/db';
 import { setDataTestId } from '@utils/test-id';
 import { cn } from '@utils/ui/styles';
-import { memo, useRef } from 'react';
+import { memo, useLayoutEffect, useRef, useState } from 'react';
 
 interface TableRegularCellProps {
   cell: Cell<any, unknown>;
@@ -15,6 +15,7 @@ interface TableRegularCellProps {
   isLastRow: boolean;
   isCellSelected: boolean;
   isColumnSelected: boolean;
+  layoutVersion: number;
   onSelect: (value: Cell<any, any>) => void;
 }
 
@@ -25,10 +26,12 @@ export const TableRegularCell = memo(
     isLastRow,
     isCellSelected,
     isColumnSelected,
+    layoutVersion,
     onSelect,
   }: TableRegularCellProps) => {
     // We need ref to check if the cell is truncated
     const cellRef = useRef<HTMLDivElement>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
 
     const handleCellClick = () => {
       onSelect(cell);
@@ -42,14 +45,16 @@ export const TableRegularCell = memo(
     });
     const isHighlighted = isCellSelected || isColumnSelected;
 
-    let isTruncated = false;
-    if (cellRef.current) {
-      isTruncated = cellRef.current.scrollWidth > cellRef.current.clientWidth;
-    }
+    useLayoutEffect(() => {
+      const element = cellRef.current;
+      if (!element) return;
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    }, [formattedValue, layoutVersion]);
 
     const cellElement = (
       <Box
-        // ref={boxRef}
+        data-truncated={isTruncated || undefined}
+        tabIndex={isTruncated ? 0 : undefined}
         data-testid={setDataTestId(`data-table-cell-container-${cell.column.id}-${cell.row.index}`)}
         className={cn(
           'whitespace-nowrap overflow-hidden border-transparent select-none',
@@ -88,12 +93,15 @@ export const TableRegularCell = memo(
       </Box>
     );
 
-    const defaultNode = isTruncated ? (
-      <Tooltip withinPortal label={formattedValue}>
+    const defaultNode = (
+      <Tooltip
+        withinPortal
+        disabled={!isTruncated}
+        events={{ hover: true, focus: true, touch: false }}
+        label={formattedValue}
+      >
         {cellElement}
       </Tooltip>
-    ) : (
-      cellElement
     );
 
     if (columnMeta?.cellRenderer) {

--- a/src/components/table/components/table-body/table-body.tsx
+++ b/src/components/table/components/table-body/table-body.tsx
@@ -10,12 +10,14 @@ export const TableBody = ({
   selectedCellId,
   onCellSelect,
   selectedCols,
+  layoutVersion,
   getRowClassName,
 }: {
   table: TableType<any>;
   selectedCellId: string | null;
   onCellSelect: (cell: Cell<any, any>) => void;
   selectedCols: Record<string, boolean>;
+  layoutVersion: number;
   getRowClassName?: GetRowClassName;
 }) => (
   <div>
@@ -66,6 +68,7 @@ export const TableBody = ({
                   isLastRow={lastRow}
                   isCellSelected={selectedCellId === cell.id}
                   isColumnSelected={selectedCols[cell.column.id]}
+                  layoutVersion={layoutVersion}
                   onSelect={onCellSelect}
                 />
               ),
@@ -80,5 +83,6 @@ export const MemoizedTableBody = memo(
   TableBody,
   (prev, next) =>
     prev.table.options.data === next.table.options.data &&
+    prev.layoutVersion === next.layoutVersion &&
     prev.getRowClassName === next.getRowClassName,
 ) as typeof TableBody;

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -99,9 +99,9 @@ export const Table = memo(
     });
 
     const { columnSizingInfo, columnSizing } = table.getState();
+    const headers = table.getFlatHeaders();
 
     const { columnSizeVars, colSizes } = useMemo(() => {
-      const headers = table.getFlatHeaders();
       const sizes: { [key: string]: number } = {};
       const sizeVars: { [key: string]: number } = {};
 
@@ -131,7 +131,7 @@ export const Table = memo(
 
       columnSizesRef.current = sizes;
       return { columnSizeVars: sizeVars, colSizes: sizes };
-    }, [columnSizing, columnSizingInfo, table]);
+    }, [columnSizing, columnSizingInfo, headers]);
 
     // Notify parent of column size changes after render (not during)
     useEffect(() => {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -6,7 +6,7 @@ import { ColumnSortSpecList, DBColumn, DBTableOrViewSchema, DataRow } from '@mod
 import { useReactTable, getCoreRowModel, ColumnDef } from '@tanstack/react-table';
 import { copyToClipboard } from '@utils/clipboard';
 import { setDataTestId } from '@utils/test-id';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { MemoizedTableBody, TableBody } from './components/table-body';
 import { TableHeadCell } from './components/thead-cell';
@@ -69,6 +69,33 @@ export const Table = memo(
       hasRows,
       schema,
     });
+    const [truncationLayoutVersion, setTruncationLayoutVersion] = useState(0);
+
+    useLayoutEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      let animationFrame: number | null = null;
+      let disposed = false;
+      const scheduleTruncationMeasurement = () => {
+        if (animationFrame !== null) return;
+        animationFrame = window.requestAnimationFrame(() => {
+          animationFrame = null;
+          if (!disposed) setTruncationLayoutVersion((version) => version + 1);
+        });
+      };
+      const resizeObserver = new ResizeObserver(scheduleTruncationMeasurement);
+
+      resizeObserver.observe(container);
+      scheduleTruncationMeasurement();
+      void document.fonts.ready.then(scheduleTruncationMeasurement);
+
+      return () => {
+        disposed = true;
+        if (animationFrame !== null) window.cancelAnimationFrame(animationFrame);
+        resizeObserver.disconnect();
+      };
+    }, [containerRef]);
 
     // We want non-reactive column sizes, that we initialize from the prop
     // and update as the table resizes (without tiggering re-renders).
@@ -259,6 +286,7 @@ export const Table = memo(
             table={table}
             selectedCellId={selectedCell.cellId}
             selectedCols={selectedCols}
+            layoutVersion={truncationLayoutVersion}
             onCellSelect={handleCellSelect}
             getRowClassName={getRowClassName}
           />
@@ -267,6 +295,7 @@ export const Table = memo(
             table={table}
             selectedCellId={selectedCell.cellId}
             selectedCols={selectedCols}
+            layoutVersion={truncationLayoutVersion}
             onCellSelect={handleCellSelect}
             getRowClassName={getRowClassName}
           />

--- a/tests/integration/data-viewer/pagination.spec.ts
+++ b/tests/integration/data-viewer/pagination.spec.ts
@@ -1,7 +1,7 @@
 import { expect, mergeTests } from '@playwright/test';
 import { getTableColumnId } from '@utils/db';
 
-import { test as dataViewTest, getHeaderCell } from '../fixtures/data-view';
+import { test as dataViewTest, getDataCellValue, getHeaderCell } from '../fixtures/data-view';
 import { test as baseTest } from '../fixtures/page';
 import { test as scriptEditorTest } from '../fixtures/script-editor';
 import { test as scriptExplorerTest } from '../fixtures/script-explorer';
@@ -61,6 +61,7 @@ test.describe('Data Viewer Pagination', () => {
   test('should show correct pagination control for larger data (multiple pages)', async ({
     generateTestData,
     waitForPaginationControl,
+    waitForDataTable,
   }) => {
     // Generate a larger dataset that spans multiple pages
     await generateTestData(101);
@@ -84,6 +85,10 @@ test.describe('Data Viewer Pagination', () => {
     await expect(paginationControl.getByTestId('pagination-control-out-of')).toHaveText(
       '2-101 out of 101 rows',
     );
+    const dataTable = await waitForDataTable();
+    const valueColumnId = getTableColumnId('unnest', 0);
+    await expect(getDataCellValue(dataTable, valueColumnId, 0)).toHaveText('2');
+    await expect(getDataCellValue(dataTable, valueColumnId, 99)).toHaveText('101');
 
     // Click back to previous page
     await navigationButtons.nth(0).click();
@@ -92,6 +97,7 @@ test.describe('Data Viewer Pagination', () => {
     await expect(paginationControl.getByTestId('pagination-control-out-of')).toHaveText(
       '1-100 out of 101 rows',
     );
+    await expect(getDataCellValue(dataTable, valueColumnId, 0)).toHaveText('1');
   });
 
   test('should handle empty data set correctly', async ({

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -9,6 +9,35 @@ import { test as scriptExplorerTest } from '../fixtures/script-explorer';
 
 const test = mergeTests(baseTest, scriptExplorerTest, scriptEditorTest, dataViewTest);
 
+const expectColumnWidthsAligned = async (
+  dataTable: Parameters<typeof getHeaderCell>[0],
+  columnNames: string[],
+  rowIndexes: number[],
+) => {
+  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
+    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
+    const headerCell = getHeaderCell(dataTable, columnId);
+
+    await expect(headerCell).toBeVisible();
+    await expect
+      .poll(() => headerCell.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeGreaterThan(40);
+
+    for (const rowIndex of rowIndexes) {
+      const dataCell = getDataCellContainer(dataTable, columnId, rowIndex);
+      await expect
+        .poll(async () => {
+          const [headerWidth, dataWidth] = await Promise.all([
+            headerCell.evaluate((element) => element.getBoundingClientRect().width),
+            dataCell.evaluate((element) => element.getBoundingClientRect().width),
+          ]);
+          return Math.abs(headerWidth - dataWidth);
+        })
+        .toBeLessThan(0.5);
+    }
+  }
+};
+
 test('Header cell width matches data cell width for special character columns', async ({
   createScriptAndSwitchToItsTab,
   fillScript,
@@ -59,19 +88,27 @@ test('Header cell width matches data cell width for special character columns', 
 });
 
 test('Column widths update when the result schema expands in the same tab', async ({
+  page,
   createScriptAndSwitchToItsTab,
-  fillScript,
   runScript,
+  scriptEditorContent,
   waitForDataTable,
 }) => {
   await createScriptAndSwitchToItsTab();
 
-  await fillScript('SELECT 1 AS initial_column;');
+  const replaceScript = async (content: string) => {
+    await scriptEditorContent.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.insertText(content);
+  };
+
+  await replaceScript('SELECT 1 AS initial_column;');
   await runScript();
-  await waitForDataTable();
+  let dataTable = await waitForDataTable();
+  await expect(getHeaderCell(dataTable, getTableColumnId('initial_column', 0))).toBeVisible();
 
   const columnNames = ['line_id', 'run_id', 'message'];
-  await fillScript(`
+  await replaceScript(`
     SELECT
       21004 + i AS line_id,
       48262306 AS run_id,
@@ -79,24 +116,156 @@ test('Column widths update when the result schema expands in the same tab', asyn
         WHEN i < 4 THEN 'ok'
         ELSE repeat('A long error message ', 50)
       END AS message
-    FROM range(6) AS rows(i);
+    FROM range(6) AS rows(i)
+    ORDER BY i;
+  `);
+  await runScript();
+
+  dataTable = await waitForDataTable();
+  await expectColumnWidthsAligned(dataTable, columnNames, [0, 4]);
+
+  const reorderedColumns = ['message', 'line_id', 'run_id'];
+  await replaceScript(`
+    SELECT
+      CASE WHEN i < 4 THEN 'reordered' ELSE repeat('Long reordered value ', 20) END AS message,
+      i AS line_id,
+      i * 10 AS run_id
+    FROM range(6) AS rows(i)
+    ORDER BY i;
+  `);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getHeaderCell(dataTable, getTableColumnId('message', 0))).toBeVisible();
+  await expectColumnWidthsAligned(dataTable, reorderedColumns, [0, 4]);
+
+  const replacementColumns = ['alpha', 'beta', 'gamma'];
+  await replaceScript(`SELECT i AS alpha, i + 1 AS beta, i + 2 AS gamma FROM range(6) rows(i);`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getHeaderCell(dataTable, getTableColumnId('alpha', 0))).toBeVisible();
+  await expectColumnWidthsAligned(dataTable, replacementColumns, [0, 4]);
+
+  await replaceScript(`SELECT 7 AS final_column;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getHeaderCell(dataTable, getTableColumnId('final_column', 0))).toBeVisible();
+  await expect(dataTable.locator('[data-testid^="data-table-header-cell-container-"]')).toHaveCount(
+    2,
+  );
+  await expectColumnWidthsAligned(dataTable, ['final_column'], [0]);
+});
+
+test('Truncation and tooltip state follow column resizing', async ({
+  page,
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  const longValue = 'Long value '.repeat(10).trim();
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`SELECT '${longValue}' AS message;`);
+  await runScript();
+
+  const dataTable = await waitForDataTable();
+  const columnId = getTableColumnId('message', 0);
+  const cell = getDataCellContainer(dataTable, columnId, 0);
+  const header = getHeaderCell(dataTable, columnId);
+  const resizeBy = async (delta: number) => {
+    const resizerBox = await header.locator('.resizer').boundingBox();
+    expect(resizerBox).not.toBeNull();
+    await page.mouse.move(resizerBox!.x + resizerBox!.width / 2, resizerBox!.y + 10);
+    await page.mouse.down();
+    await page.mouse.move(resizerBox!.x + delta, resizerBox!.y + 10);
+    await page.mouse.up();
+  };
+
+  await expect
+    .poll(() =>
+      cell.evaluate((element) => {
+        const value = element.firstElementChild as HTMLElement;
+        return value.scrollWidth - value.clientWidth;
+      }),
+    )
+    .toBeGreaterThan(0);
+  await expect(cell).toHaveAttribute('data-truncated', 'true');
+
+  await resizeBy(750);
+  await expect(cell).not.toHaveAttribute('data-truncated', 'true');
+  await page.mouse.move(0, 0);
+  await cell.hover();
+  await expect(page.getByRole('tooltip')).toBeHidden();
+
+  await resizeBy(-750);
+  await expect(cell).toHaveAttribute('data-truncated', 'true');
+  await page.mouse.move(0, 0);
+  await cell.hover();
+  await expect(page.getByRole('tooltip')).toHaveText(longValue);
+  await page.mouse.move(0, 0);
+  await cell.focus();
+  await expect(page.getByRole('tooltip')).toHaveText(longValue);
+
+  await resizeBy(750);
+  await expect(cell).not.toHaveAttribute('data-truncated', 'true');
+  await expect(page.getByRole('tooltip')).toBeHidden();
+});
+
+test('Narrow tables keep headers aligned while scrolling', async ({
+  page,
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  await page.setViewportSize({ width: 640, height: 720 });
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`
+    SELECT
+      i AS first_column,
+      i AS second_column,
+      i AS third_column,
+      i AS fourth_column,
+      i AS fifth_column
+    FROM range(200) AS rows(i)
+    ORDER BY i;
   `);
   await runScript();
 
   const dataTable = await waitForDataTable();
+  const scrollContainer = dataTable.locator('..');
+  const firstHeader = getHeaderCell(dataTable, getTableColumnId('first_column', 0));
+  const initialHeaderY = await firstHeader.evaluate((element) => element.getBoundingClientRect().y);
 
-  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
-    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
-    const headerBoundingBox = await getHeaderCell(dataTable, columnId).boundingBox();
-
-    for (const rowIndex of [0, 4]) {
-      const dataBoundingBox = await getDataCellContainer(
-        dataTable,
-        columnId,
-        rowIndex,
-      ).boundingBox();
-
-      expect(dataBoundingBox?.width).toBeCloseTo(headerBoundingBox?.width as number, 1);
-    }
-  }
+  await expect
+    .poll(() => scrollContainer.evaluate((element) => element.scrollWidth - element.clientWidth))
+    .toBeGreaterThan(0);
+  await scrollContainer.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect
+    .poll(() => scrollContainer.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(0);
+  await expect
+    .poll(() => scrollContainer.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  await expect
+    .poll(() => firstHeader.evaluate((element) => element.getBoundingClientRect().y))
+    .toBeCloseTo(initialHeaderY, 0);
+  await expect
+    .poll(async () => {
+      const [headerX, cellX] = await Promise.all([
+        firstHeader.evaluate((element) => element.getBoundingClientRect().x),
+        getDataCellContainer(dataTable, getTableColumnId('first_column', 0), 99).evaluate(
+          (element) => element.getBoundingClientRect().x,
+        ),
+      ]);
+      return Math.abs(headerX - cellX);
+    })
+    .toBeLessThan(0.5);
+  await expectColumnWidthsAligned(
+    dataTable,
+    ['first_column', 'second_column', 'third_column', 'fourth_column', 'fifth_column'],
+    [0, 99],
+  );
 });

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -57,3 +57,46 @@ test('Header cell width matches data cell width for special character columns', 
     expect(headerBoundingBox?.width).toBeCloseTo(dataBoundingBox?.width as number, 1);
   }
 });
+
+test('Column widths update when the result schema expands in the same tab', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+
+  await fillScript('SELECT 1 AS initial_column;');
+  await runScript();
+  await waitForDataTable();
+
+  const columnNames = ['line_id', 'run_id', 'message'];
+  await fillScript(`
+    SELECT
+      21004 + i AS line_id,
+      48262306 AS run_id,
+      CASE
+        WHEN i < 4 THEN 'ok'
+        ELSE repeat('A long error message ', 50)
+      END AS message
+    FROM range(6) AS rows(i);
+  `);
+  await runScript();
+
+  const dataTable = await waitForDataTable();
+
+  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
+    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
+    const headerBoundingBox = await getHeaderCell(dataTable, columnId).boundingBox();
+
+    for (const rowIndex of [0, 4]) {
+      const dataBoundingBox = await getDataCellContainer(
+        dataTable,
+        columnId,
+        rowIndex,
+      ).boundingBox();
+
+      expect(dataBoundingBox?.width).toBeCloseTo(headerBoundingBox?.width as number, 1);
+    }
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,7 +10631,7 @@ __metadata:
     react-icons: "npm:5.7.0"
     react-is: "npm:19.2.7"
     react-markdown: "npm:10.1.0"
-    react-router: "npm:7.18.1"
+    react-router: "npm:7.18.2"
     reactflow: "npm:11.11.4"
     recharts: "npm:3.9.2"
     sql-formatter: "npm:15.8.2"
@@ -11082,9 +11082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.1":
-  version: 7.18.1
-  resolution: "react-router@npm:7.18.1"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -11094,7 +11094,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
+  checksum: 10c0/513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- recalculate truncation after mount, content changes, font readiness, and table resize
- use one table-level `ResizeObserver` instead of one observer per cell
- expose truncated values through hover and keyboard focus
- strengthen schema transitions across expansion, reorder, same-count replacement, and contraction
- cover narrow viewport scrolling, sticky header geometry, pagination contents, and web-first width assertions

## Validation

- `yarn typecheck`
- ESLint with no errors
- 73 Jest suites, 1189 tests passed
- Playwright table layout and pagination: 8 passed
- integration build passed

## Stack

This PR is based on #334. Real browser geometry, focus, tooltip, scrolling, and pagination behavior remain in Playwright.
