### PR TITLE
Persist table column widths by stable ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-icons": "5.7.0",
     "react-is": "19.2.7",
     "react-markdown": "10.1.0",
-    "react-router": "7.18.1",
+    "react-router": "7.18.2",
     "reactflow": "11.11.4",
     "recharts": "3.9.2",
     "sql-formatter": "15.8.2",

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -3,22 +3,28 @@ import { Text } from '@mantine/core';
 import { useDidUpdate, useHotkeys } from '@mantine/hooks';
 import { DataTableSlice } from '@models/data-adapter';
 import { ColumnSortSpecList, DBColumn, DBTableOrViewSchema, DataRow } from '@models/db';
-import { useReactTable, getCoreRowModel, ColumnDef } from '@tanstack/react-table';
+import {
+  useReactTable,
+  getCoreRowModel,
+  ColumnDef,
+  ColumnSizingState,
+  OnChangeFn,
+} from '@tanstack/react-table';
 import { copyToClipboard } from '@utils/clipboard';
 import { setDataTestId } from '@utils/test-id';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { MemoizedTableBody, TableBody } from './components/table-body';
 import { TableHeadCell } from './components/thead-cell';
 import { useNoResultsPosition, useTableSelection } from './hooks';
-import { getTableColumns } from './utils';
+import { ColumnSizeCache, getTableColumns, getTableSizing, sanitizeColumnSizeCache } from './utils';
 
 interface TableProps {
   dataSlice: DataTableSlice;
   schema: DBTableOrViewSchema;
   sort: ColumnSortSpecList;
   visible: boolean;
-  initialColumnSizes?: Record<string, number>;
+  initialColumnSizes?: ColumnSizeCache;
   columns?: ColumnDef<DataRow, any>[];
   // Undefined means sorting is blocked
   onSort?: (columnId: string) => void;
@@ -27,7 +33,7 @@ interface TableProps {
   onRowSelectChange: () => void;
   onCellSelectChange: () => void;
   onColumnSelectChange: (column: DBColumn | null) => void;
-  onColumnResizeChange?: (columnSizes: Record<string, number>) => void;
+  onColumnResizeChange?: (columnSizes: ColumnSizeCache) => void;
   getRowClassName?: GetRowClassName<DataRow>;
 }
 
@@ -70,24 +76,24 @@ export const Table = memo(
       schema,
     });
 
-    // We want non-reactive column sizes, that we initialize from the prop
-    // and update as the table resizes (without tiggering re-renders).
-    // This allows us to set the default column sizes in `getTableColumns`
-    // whenever the schema is changed and otherwise keep column defs memoized.
-    const columnSizesRef = useRef<Record<string, number>>(initialColumnSizes);
-
     const tableColumns = useMemo(() => {
       if (columns) {
         return columns;
       }
       return getTableColumns({
         schema,
-        initialColumnSizes: columnSizesRef.current,
         onRowSelectionChange,
       });
-      // Note that `columnSizesRef.current` is not a dependency here intentionally!
-      // See the reasoning above.
     }, [columns, schema, onRowSelectionChange]);
+
+    const [controlledColumnSizing, setColumnSizing] = useState<ColumnSizingState>(() =>
+      sanitizeColumnSizeCache(initialColumnSizes),
+    );
+    const columnSizingWasChanged = useRef(false);
+    const handleColumnSizingChange = useCallback<OnChangeFn<ColumnSizingState>>((updater) => {
+      columnSizingWasChanged.current = true;
+      setColumnSizing(updater);
+    }, []);
 
     const table = useReactTable({
       data: dataSlice.data,
@@ -95,48 +101,30 @@ export const Table = memo(
       columns: tableColumns,
       columnResizeMode: 'onEnd',
       getCoreRowModel: getCoreRowModel(),
-      state: { rowSelection: selectedRows },
+      onColumnSizingChange: handleColumnSizingChange,
+      state: { columnSizing: controlledColumnSizing, rowSelection: selectedRows },
     });
 
     const { columnSizingInfo, columnSizing } = table.getState();
     const headers = table.getFlatHeaders();
 
-    const { columnSizeVars, colSizes } = useMemo(() => {
-      const sizes: { [key: string]: number } = {};
-      const sizeVars: { [key: string]: number } = {};
-
-      for (let i = 0; i < headers.length; i += 1) {
-        const header = headers[i]!;
-
-        sizeVars[`--header-${header.index}-size`] = header.getSize();
-        sizeVars[`--col-${header.index}-size`] = header.column.getSize();
-        sizes[header.index] = header.getSize();
-      }
-
-      const sizingKeys = Object.keys(columnSizing);
-      for (let i = 0; i < sizingKeys.length; i += 1) {
-        const key = sizingKeys[i]!;
-        if (!(key in sizeVars)) {
-          const existingSize = columnSizing[key];
-          if (typeof existingSize === 'number') {
-            sizeVars[`--col-${key}-size`] = existingSize;
-          }
-        }
-      }
+    const { columnSizeVars, persistedColumnSizes } = useMemo(() => {
+      const sizing = getTableSizing(headers);
 
       // Access resizing state so memo updates when the active resize target changes
       if (columnSizingInfo.isResizingColumn !== null) {
         // no-op
       }
 
-      columnSizesRef.current = sizes;
-      return { columnSizeVars: sizeVars, colSizes: sizes };
+      return sizing;
     }, [columnSizing, columnSizingInfo, headers]);
 
     // Notify parent of column size changes after render (not during)
     useEffect(() => {
-      onColumnResizeChange?.(colSizes);
-    }, [colSizes, onColumnResizeChange]);
+      if (!columnSizingWasChanged.current) return;
+      columnSizingWasChanged.current = false;
+      onColumnResizeChange?.(persistedColumnSizes);
+    }, [onColumnResizeChange, persistedColumnSizes]);
 
     useDidUpdate(() => {
       clearSelection();

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -99,9 +99,9 @@ export const Table = memo(
     });
 
     const { columnSizingInfo, columnSizing } = table.getState();
+    const headers = table.getFlatHeaders();
 
     const { columnSizeVars, colSizes } = useMemo(() => {
-      const headers = table.getFlatHeaders();
       const sizes: { [key: string]: number } = {};
       const sizeVars: { [key: string]: number } = {};
 
@@ -131,7 +131,7 @@ export const Table = memo(
 
       columnSizesRef.current = sizes;
       return { columnSizeVars: sizeVars, colSizes: sizes };
-    }, [columnSizing, columnSizingInfo, table]);
+    }, [columnSizing, columnSizingInfo, headers]);
 
     // Notify parent of column size changes after render (not during)
     useEffect(() => {

--- a/src/components/table/utils/get-table-columns.tsx
+++ b/src/components/table/utils/get-table-columns.tsx
@@ -10,7 +10,6 @@ import { TableMeta } from '../model';
 
 interface GetTableColumnsProps {
   schema: DBColumn[];
-  initialColumnSizes?: Record<string, number>;
   onRowSelectionChange: (
     cell: CellContext<DataRow, any>,
     e: React.MouseEvent<Element, MouseEvent>,
@@ -19,11 +18,7 @@ interface GetTableColumnsProps {
 
 const emptyColumns = [] as any[];
 
-export const getTableColumns = ({
-  schema,
-  initialColumnSizes,
-  onRowSelectionChange,
-}: GetTableColumnsProps) => {
+export const getTableColumns = ({ schema, onRowSelectionChange }: GetTableColumnsProps) => {
   const indexColumnId = findUniqueName('__index__', (colId) =>
     schema.some((col) => col.id === colId),
   );
@@ -62,7 +57,7 @@ export const getTableColumns = ({
             header: col.name,
             meta: { type: col.sqlType, name: col.name },
             minSize: 100,
-            size: initialColumnSizes?.[col.name] || 200,
+            size: 200,
             id: col.id,
           };
         }),

--- a/src/components/table/utils/get-table-sizing.ts
+++ b/src/components/table/utils/get-table-sizing.ts
@@ -1,0 +1,40 @@
+import { DataRow } from '@models/db';
+import { Header } from '@tanstack/react-table';
+
+export type ColumnSizeCache = Record<string, number>;
+
+export const sanitizeColumnSizeCache = (
+  columnSizes: ColumnSizeCache | undefined,
+): ColumnSizeCache => {
+  if (!columnSizes) return {};
+
+  return Object.fromEntries(
+    Object.entries(columnSizes).filter(
+      ([columnId, size]) => !/^\d+$/.test(columnId) && Number.isFinite(size) && size > 0,
+    ),
+  );
+};
+
+type TableSizing = {
+  columnSizeVars: Record<string, number>;
+  persistedColumnSizes: ColumnSizeCache;
+};
+
+/**
+ * Build the index-based CSS variables used by table cells and the stable,
+ * column-id-based map persisted between table mounts.
+ */
+export const getTableSizing = (headers: Header<DataRow, unknown>[]): TableSizing => {
+  const columnSizeVars: Record<string, number> = {};
+  const persistedColumnSizes: ColumnSizeCache = {};
+
+  for (const header of headers) {
+    const headerSize = header.getSize();
+
+    columnSizeVars[`--header-${header.index}-size`] = headerSize;
+    columnSizeVars[`--col-${header.index}-size`] = header.column.getSize();
+    persistedColumnSizes[header.column.id] = headerSize;
+  }
+
+  return { columnSizeVars, persistedColumnSizes };
+};

--- a/src/components/table/utils/index.ts
+++ b/src/components/table/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './get-table-columns';
+export * from './get-table-sizing';

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -100,3 +100,127 @@ test('Column widths update when the result schema expands in the same tab', asyn
     }
   }
 });
+
+test('Column resize persists across schema changes and remounts', async ({
+  page,
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  reloadPage,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`SELECT 'before' AS message;`);
+  await runScript();
+
+  let dataTable = await waitForDataTable();
+  const messageColumnId = getTableColumnId('message', 0);
+  let messageHeader = getHeaderCell(dataTable, messageColumnId);
+  const initialWidth = await messageHeader.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  const resizer = messageHeader.locator('.resizer');
+  const resizerBox = await resizer.boundingBox();
+
+  expect(resizerBox).not.toBeNull();
+  await page.mouse.move(resizerBox!.x + resizerBox!.width / 2, resizerBox!.y + 10);
+  await page.mouse.down();
+  await page.mouse.move(resizerBox!.x + 120, resizerBox!.y + 10);
+  await page.mouse.up();
+
+  await expect
+    .poll(() => messageHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeGreaterThan(initialWidth + 100);
+  const resizedWidth = await messageHeader.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+
+  await fillScript(`SELECT 'after' AS message, 2 AS extra;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  messageHeader = getHeaderCell(dataTable, messageColumnId);
+
+  await expect
+    .poll(() => messageHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(resizedWidth, 0);
+  await expect
+    .poll(() =>
+      getDataCellContainer(dataTable, messageColumnId, 0).evaluate(
+        (element) => element.getBoundingClientRect().width,
+      ),
+    )
+    .toBeCloseTo(resizedWidth, 0);
+
+  await reloadPage();
+  dataTable = await waitForDataTable();
+  messageHeader = getHeaderCell(dataTable, messageColumnId);
+
+  await expect
+    .poll(() => messageHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(resizedWidth, 0);
+
+  await messageHeader.locator('.resizer').dblclick();
+  await expect
+    .poll(() => messageHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(200, 0);
+});
+
+test('Duplicate column names keep independent persisted widths', async ({
+  page,
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  reloadPage,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`SELECT 'first' AS column_name, 'second' AS column_name;`);
+  await runScript();
+
+  let dataTable = await waitForDataTable();
+  const firstColumnId = getTableColumnId('column_name', 0);
+  const secondColumnId = getTableColumnId('column_name', 1);
+  const firstHeader = getHeaderCell(dataTable, firstColumnId);
+  let secondHeader = getHeaderCell(dataTable, secondColumnId);
+  const firstWidth = await firstHeader.evaluate((element) => element.getBoundingClientRect().width);
+  const secondInitialWidth = await secondHeader.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  const resizerBox = await secondHeader.locator('.resizer').boundingBox();
+
+  expect(resizerBox).not.toBeNull();
+  await page.mouse.move(resizerBox!.x + resizerBox!.width / 2, resizerBox!.y + 10);
+  await page.mouse.down();
+  await page.mouse.move(resizerBox!.x + 120, resizerBox!.y + 10);
+  await page.mouse.up();
+
+  await expect
+    .poll(() => secondHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeGreaterThan(secondInitialWidth + 100);
+  const secondResizedWidth = await secondHeader.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  await expect
+    .poll(() => firstHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(firstWidth, 0);
+
+  await fillScript(`SELECT 'first-new' AS column_name, 'second-new' AS column_name, 3 AS extra;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  secondHeader = getHeaderCell(dataTable, secondColumnId);
+  await expect
+    .poll(() => secondHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(secondResizedWidth, 0);
+
+  await reloadPage();
+  dataTable = await waitForDataTable();
+  secondHeader = getHeaderCell(dataTable, secondColumnId);
+  await expect
+    .poll(() => secondHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(secondResizedWidth, 0);
+
+  await secondHeader.locator('.resizer').dblclick();
+  await expect
+    .poll(() => secondHeader.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeCloseTo(200, 0);
+});

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -57,3 +57,46 @@ test('Header cell width matches data cell width for special character columns', 
     expect(headerBoundingBox?.width).toBeCloseTo(dataBoundingBox?.width as number, 1);
   }
 });
+
+test('Column widths update when the result schema expands in the same tab', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+
+  await fillScript('SELECT 1 AS initial_column;');
+  await runScript();
+  await waitForDataTable();
+
+  const columnNames = ['line_id', 'run_id', 'message'];
+  await fillScript(`
+    SELECT
+      21004 + i AS line_id,
+      48262306 AS run_id,
+      CASE
+        WHEN i < 4 THEN 'ok'
+        ELSE repeat('A long error message ', 50)
+      END AS message
+    FROM range(6) AS rows(i);
+  `);
+  await runScript();
+
+  const dataTable = await waitForDataTable();
+
+  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
+    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
+    const headerBoundingBox = await getHeaderCell(dataTable, columnId).boundingBox();
+
+    for (const rowIndex of [0, 4]) {
+      const dataBoundingBox = await getDataCellContainer(
+        dataTable,
+        columnId,
+        rowIndex,
+      ).boundingBox();
+
+      expect(dataBoundingBox?.width).toBeCloseTo(headerBoundingBox?.width as number, 1);
+    }
+  }
+});

--- a/tests/unit/components/table/get-table-sizing.test.ts
+++ b/tests/unit/components/table/get-table-sizing.test.ts
@@ -1,0 +1,51 @@
+import { getTableSizing, sanitizeColumnSizeCache } from '@components/table/utils/get-table-sizing';
+import { describe, expect, it } from '@jest/globals';
+import { Header } from '@tanstack/react-table';
+
+const createHeader = (index: number, columnId: string, size: number) =>
+  ({
+    index,
+    getSize: () => size,
+    column: {
+      id: columnId,
+      getSize: () => size,
+    },
+  }) as Header<any, unknown>;
+
+describe('getTableSizing', () => {
+  it('uses indexes for CSS variables and stable column IDs for persistence', () => {
+    const sizing = getTableSizing([
+      createHeader(0, '__index__', 46),
+      createHeader(1, '0_column_name', 320),
+      createHeader(2, '1_column_name', 180),
+    ]);
+
+    expect(sizing.columnSizeVars).toEqual({
+      '--header-0-size': 46,
+      '--col-0-size': 46,
+      '--header-1-size': 320,
+      '--col-1-size': 320,
+      '--header-2-size': 180,
+      '--col-2-size': 180,
+    });
+    expect(sizing.persistedColumnSizes).toEqual({
+      __index__: 46,
+      '0_column_name': 320,
+      '1_column_name': 180,
+    });
+  });
+});
+
+describe('sanitizeColumnSizeCache', () => {
+  it('keeps stable column IDs and rejects legacy numeric or invalid entries', () => {
+    expect(
+      sanitizeColumnSizeCache({
+        0: 999,
+        message: 320,
+        message_2: 180,
+        invalid: Number.NaN,
+        negative: -20,
+      }),
+    ).toEqual({ message: 320, message_2: 180 });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,7 +10631,7 @@ __metadata:
     react-icons: "npm:5.7.0"
     react-is: "npm:19.2.7"
     react-markdown: "npm:10.1.0"
-    react-router: "npm:7.18.1"
+    react-router: "npm:7.18.2"
     reactflow: "npm:11.11.4"
     recharts: "npm:3.9.2"
     sql-formatter: "npm:15.8.2"
@@ -11082,9 +11082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.1":
-  version: 7.18.1
-  resolution: "react-router@npm:7.18.1"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -11094,7 +11094,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
+  checksum: 10c0/513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- persist column widths by TanStack `column.id` while keeping numeric indexes only for CSS variables
- ignore legacy numeric cache entries until the user performs the next resize
- keep double-click reset behavior at the 200px default
- cover resize, schema changes, reload/remount, and duplicate display names

## Why

The table wrote cached widths under numeric header indexes but restored them under column names. As a result, a resized column silently returned to its default after remount or a result-schema change. Display names are also not unique, so they cannot be the persistence key.

## Validation

- `yarn typecheck`
- ESLint with no errors
- 74 Jest suites, 1191 tests passed
- targeted Playwright: resize/remount and duplicate-name scenarios, 2 passed
- integration build passed

## Stack

This PR is based on #334 so the original schema-width regression remains a narrow, independently reviewable change.
