### PR TITLE
Reset table selections after data refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-icons": "5.7.0",
     "react-is": "19.2.7",
     "react-markdown": "10.1.0",
-    "react-router": "7.18.1",
+    "react-router": "7.18.2",
     "reactflow": "11.11.4",
     "recharts": "3.9.2",
     "sql-formatter": "15.8.2",

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -15,6 +15,7 @@ import { getTableColumns } from './utils';
 
 interface TableProps {
   dataSlice: DataTableSlice;
+  dataSourceVersion: number;
   schema: DBTableOrViewSchema;
   sort: ColumnSortSpecList;
   visible: boolean;
@@ -34,6 +35,7 @@ interface TableProps {
 export const Table = memo(
   ({
     dataSlice,
+    dataSourceVersion,
     schema,
     sort,
     visible,
@@ -140,7 +142,7 @@ export const Table = memo(
 
     useDidUpdate(() => {
       clearSelection();
-    }, [JSON.stringify(schema)]);
+    }, [dataSourceVersion]);
 
     useHotkeys([
       [

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -99,9 +99,9 @@ export const Table = memo(
     });
 
     const { columnSizingInfo, columnSizing } = table.getState();
+    const headers = table.getFlatHeaders();
 
     const { columnSizeVars, colSizes } = useMemo(() => {
-      const headers = table.getFlatHeaders();
       const sizes: { [key: string]: number } = {};
       const sizeVars: { [key: string]: number } = {};
 
@@ -131,7 +131,7 @@ export const Table = memo(
 
       columnSizesRef.current = sizes;
       return { columnSizeVars: sizeVars, colSizes: sizes };
-    }, [columnSizing, columnSizingInfo, table]);
+    }, [columnSizing, columnSizingInfo, headers]);
 
     // Notify parent of column size changes after render (not during)
     useEffect(() => {

--- a/src/features/tab-view/components/data-view/data-view.tsx
+++ b/src/features/tab-view/components/data-view/data-view.tsx
@@ -404,6 +404,7 @@ export const DataView = ({
           <div className="flex-1 min-h-0 overflow-auto px-3 custom-scroll-hidden pb-6">
             <Table
               dataSlice={dataSlice}
+              dataSourceVersion={dataAdapter.dataSourceVersion}
               schema={dataAdapter.currentSchema}
               sort={dataAdapter.sort}
               visible={!!active}

--- a/src/features/tab-view/hooks/use-column-summary.tsx
+++ b/src/features/tab-view/hooks/use-column-summary.tsx
@@ -11,14 +11,23 @@ export const useColumnSummary = (dataAdapter: DataAdapterApi) => {
 
   // Cache to store previously calculated column summaries
   const summaryCache = useRef<Map<string, string>>(new Map());
+  const requestGeneration = useRef(0);
+
+  const resetTotal = useCallback(() => {
+    requestGeneration.current += 1;
+    setColumnTotal(null);
+    setIsLoading(false);
+    setColumnAggType('count');
+  }, []);
 
   const calculateColumnSummary = useCallback(
     async (column: DBColumn | null) => {
       if (!column) {
-        setColumnTotal(null);
-        setIsLoading(false);
+        resetTotal();
         return;
       }
+
+      const requestId = ++requestGeneration.current;
 
       try {
         const isNumeric = isNumberType(column.sqlType);
@@ -32,6 +41,7 @@ export const useColumnSummary = (dataAdapter: DataAdapterApi) => {
         if (summaryCache.current.has(cacheKey)) {
           const cachedValue = summaryCache.current.get(cacheKey);
           setColumnTotal(cachedValue || null);
+          setIsLoading(false);
           return;
         }
 
@@ -40,6 +50,7 @@ export const useColumnSummary = (dataAdapter: DataAdapterApi) => {
 
         const totalValue = await dataAdapter.getColumnAggregate(column.name, aggType);
 
+        if (requestId !== requestGeneration.current) return;
         setIsLoading(false);
 
         if (totalValue !== undefined) {
@@ -52,22 +63,20 @@ export const useColumnSummary = (dataAdapter: DataAdapterApi) => {
           summaryCache.current.set(cacheKey, formattedValue);
         }
       } catch (error) {
+        if (requestId !== requestGeneration.current) return;
         const autoCancelled = error instanceof CancelledOperation ? error.isSystemCancelled : false;
 
         if (!autoCancelled) console.error('Error calculating column summary:', error);
         setIsLoading(false);
       }
     },
-    [dataAdapter.getColumnAggregate],
+    [dataAdapter.getColumnAggregate, resetTotal],
   );
-
-  const resetTotal = useCallback(() => {
-    setColumnTotal(null);
-  }, []);
 
   // Clear the cache when the data source changes
   useDidUpdate(() => {
     summaryCache.current.clear();
+    resetTotal();
   }, [dataAdapter.dataSourceVersion]);
 
   return {

--- a/tests/integration/data-viewer/copy-data.spec.ts
+++ b/tests/integration/data-viewer/copy-data.spec.ts
@@ -95,6 +95,76 @@ test('Should copy cell value', async ({
   }
 });
 
+test('Should clear cell selection when same-schema data is refreshed', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+  page,
+  context,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`SELECT 'old' AS value;`);
+  await runScript();
+
+  let dataTable = await waitForDataTable();
+  const columnId = getTableColumnId('value', 0);
+  await getDataCellContainer(dataTable, columnId, 0).click();
+  await page.keyboard.press('ControlOrMeta+c', { delay: 100 });
+  await expect.poll(() => getClipboardContent(page)).toBe('old');
+
+  await fillScript(`SELECT 'new' AS value;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getDataCellContainer(dataTable, columnId, 0)).toHaveText('new');
+
+  await page.evaluate(() => navigator.clipboard.writeText('selection-cleared'));
+  await page.keyboard.press('ControlOrMeta+c', { delay: 100 });
+  await expect.poll(() => getClipboardContent(page)).toBe('selection-cleared');
+});
+
+test('Should clear row, column, and aggregate selection after a data refresh', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+  page,
+  context,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await createScriptAndSwitchToItsTab();
+  await fillScript(`SELECT value FROM (VALUES (1), (2)) AS source(value) ORDER BY value;`);
+  await runScript();
+
+  let dataTable = await waitForDataTable();
+  await getDataCellContainer(dataTable, '__index__', 0).click();
+  await page.keyboard.press('ControlOrMeta+c', { delay: 100 });
+  await expect.poll(() => getClipboardContent(page)).toBe('1');
+
+  await fillScript(`SELECT value FROM (VALUES (10), (20)) AS source(value) ORDER BY value;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getDataCellContainer(dataTable, getTableColumnId('value', 0), 0)).toHaveText('10');
+
+  await page.evaluate(() => navigator.clipboard.writeText('row-selection-cleared'));
+  await page.keyboard.press('ControlOrMeta+c', { delay: 100 });
+  await expect.poll(() => getClipboardContent(page)).toBe('row-selection-cleared');
+
+  await getHeaderCell(dataTable, getTableColumnId('value', 0)).click();
+  await expect(page.getByText('SUM: 30', { exact: true })).toBeVisible();
+
+  await fillScript(`SELECT value FROM (VALUES (100), (200)) AS source(value) ORDER BY value;`);
+  await runScript();
+  dataTable = await waitForDataTable();
+  await expect(getDataCellContainer(dataTable, getTableColumnId('value', 0), 0)).toHaveText('100');
+  await expect(page.getByText('SUM: 30', { exact: true })).toBeHidden();
+
+  await page.evaluate(() => navigator.clipboard.writeText('column-selection-cleared'));
+  await page.keyboard.press('ControlOrMeta+c', { delay: 100 });
+  await expect.poll(() => getClipboardContent(page)).toBe('column-selection-cleared');
+});
+
 test('Should copy rows with selection modifiers', async ({
   createScriptAndSwitchToItsTab,
   fillScript,

--- a/tests/integration/data-viewer/table-layout.spec.ts
+++ b/tests/integration/data-viewer/table-layout.spec.ts
@@ -57,3 +57,46 @@ test('Header cell width matches data cell width for special character columns', 
     expect(headerBoundingBox?.width).toBeCloseTo(dataBoundingBox?.width as number, 1);
   }
 });
+
+test('Column widths update when the result schema expands in the same tab', async ({
+  createScriptAndSwitchToItsTab,
+  fillScript,
+  runScript,
+  waitForDataTable,
+}) => {
+  await createScriptAndSwitchToItsTab();
+
+  await fillScript('SELECT 1 AS initial_column;');
+  await runScript();
+  await waitForDataTable();
+
+  const columnNames = ['line_id', 'run_id', 'message'];
+  await fillScript(`
+    SELECT
+      21004 + i AS line_id,
+      48262306 AS run_id,
+      CASE
+        WHEN i < 4 THEN 'ok'
+        ELSE repeat('A long error message ', 50)
+      END AS message
+    FROM range(6) AS rows(i);
+  `);
+  await runScript();
+
+  const dataTable = await waitForDataTable();
+
+  for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex += 1) {
+    const columnId = getTableColumnId(columnNames[columnIndex], columnIndex);
+    const headerBoundingBox = await getHeaderCell(dataTable, columnId).boundingBox();
+
+    for (const rowIndex of [0, 4]) {
+      const dataBoundingBox = await getDataCellContainer(
+        dataTable,
+        columnId,
+        rowIndex,
+      ).boundingBox();
+
+      expect(dataBoundingBox?.width).toBeCloseTo(headerBoundingBox?.width as number, 1);
+    }
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,7 +10631,7 @@ __metadata:
     react-icons: "npm:5.7.0"
     react-is: "npm:19.2.7"
     react-markdown: "npm:10.1.0"
-    react-router: "npm:7.18.1"
+    react-router: "npm:7.18.2"
     reactflow: "npm:11.11.4"
     recharts: "npm:3.9.2"
     sql-formatter: "npm:15.8.2"
@@ -11082,9 +11082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.1":
-  version: 7.18.1
-  resolution: "react-router@npm:7.18.1"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -11094,7 +11094,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
+  checksum: 10c0/513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- use `dataSourceVersion` as the table reset token instead of schema equality
- clear cell, row, and column selection for every new result
- reset aggregate display/loading state and reject late aggregate completions from an older result
- cover same-schema `old -> new` refreshes for cell, row, column, clipboard, and aggregate behavior

## Why

A rerun with the same aliases and SQL types retained the same cell IDs. The visible table showed new values, but copy could still use the old selected value, and an in-flight aggregate could repopulate stale footer state.

## Validation

- `yarn typecheck`
- ESLint with no errors
- 73 Jest suites, 1189 tests passed
- targeted Playwright: 2 same-schema refresh scenarios passed
- integration build passed

## Stack

This PR is based on #334 and does not change public APIs.
